### PR TITLE
Allow multiple pages per frame + Correctly parse script initiators

### DIFF
--- a/index.js
+++ b/index.js
@@ -328,6 +328,10 @@ module.exports = {
                   params.redirectResponse,
                   page
                 );
+
+                entry._initiator_type = 'redirect';
+                entry._initiator = params.redirectResponse.url;
+                delete entry._initiator_line;
               } else {
                 debug(
                   "Couldn't find original request for redirect response: " +

--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ const {
 const max = Math.max;
 
 const defaultOptions = {
-  includeResourcesFromDiskCache: false
+  includeResourcesFromDiskCache: false,
+  splitPagesWithinFrame: false
 };
 
 const isEmpty = o => !o;
@@ -190,8 +191,13 @@ module.exports = {
               entry => entry.__frameId === frameId
             );
 
-            if (rootFrameMappings.has(frameId) || previousFrameId) {
+            if (rootFrameMappings.has(frameId)) {
               // This is a sub frame, there's already a page for the root frame
+              continue;
+            }
+
+            if (options.splitPagesWithinFrame === false && previousFrameId) {
+              // We already have a page for the frame and the option says not to create a separate one
               continue;
             }
 
@@ -221,7 +227,7 @@ module.exports = {
             }
             const frameId =
               rootFrameMappings.get(params.frameId) || params.frameId;
-            const page = pages.find(page => page.__frameId === frameId);
+            const page = pages.filter(page => page.__frameId === frameId).pop();
             if (!page) {
               debug(
                 'Request will be sent with requestId ' +
@@ -364,7 +370,7 @@ module.exports = {
 
             const frameId =
               rootFrameMappings.get(params.frameId) || params.frameId;
-            const page = pages.find(page => page.__frameId === frameId);
+            const page = pages.filter(page => page.__frameId === frameId).pop();
             if (!page) {
               debug(
                 'Received network response for requestId ' +

--- a/index.js
+++ b/index.js
@@ -269,12 +269,36 @@ module.exports = {
               __frameId: params.frameId,
               _initialPriority: request.initialPriority,
               _priority: request.initialPriority,
-              _initiator: params.initiator.url,
-              _initiator_line: params.initiator.lineNumber,
               pageref: currentPageId,
               request: req,
               time: 0
             };
+
+            switch (params.initiator.type) {
+              case 'script':
+                if (
+                  params.initiator.stack
+                  && params.initiator.stack.callFrames
+                  && params.initiator.stack.callFrames.length > 0
+                ) {
+                  const firstCallFrame = params.initiator.stack.callFrames[params.initiator.stack.callFrames.length - 1];
+                  entry._initiator = firstCallFrame.url;
+                  entry._initiator_line = firstCallFrame.lineNumber;
+                  entry._initiator_type = params.initiator.type;
+                }
+                break;
+
+              case 'parser':
+                entry._initiator = params.initiator.url;
+                entry._initiator_line = params.initiator.lineNumber;
+                entry._initiator_type = params.initiator.type;
+                break;
+
+              default:
+                // Nothing we can do (no data is provided)
+                entry._initiator_type = params.initiator.type;
+                break;
+            }            
 
             if (params.redirectResponse) {
               const previousEntry = entries.find(

--- a/index.js
+++ b/index.js
@@ -257,7 +257,7 @@ module.exports = {
               headersSize: -1,
               bodySize: isEmpty(request.postData) ? 0 : request.postData.length,
               cookies: parseRequestCookies(cookieHeader),
-              headers: parseHeaders(request.headers)
+              headers: parseHeaders(request.headers),
             };
 
             const entry = {
@@ -267,11 +267,14 @@ module.exports = {
               __wallTime: params.wallTime,
               __requestId: params.requestId,
               __frameId: params.frameId,
+              _type: params.type,
+              _requestId: params.requestId,
+              _frameId: params.frameId,
               _initialPriority: request.initialPriority,
               _priority: request.initialPriority,
               pageref: currentPageId,
               request: req,
-              time: 0
+              time: 0,
             };
 
             function parseStackTrace(stackTrace) {


### PR DESCRIPTION
I have added two modifications that I think would be interesting for everyone:

1) Multiple pages per frame
I wanted the HAR log to have 1 page per URL whereas the existing behavior was to get 1 page per frame so I added an option to get 1 page per URL (defaults to `false` so the default behavior is still the same).

2) Initiators parsing
When the initiator type is "script" then the initiator URL and line number are empty but can be taken from the call stack. This patch does this.

Happy to make modifications to my PR if you tell me what it needs before it can be merged.