### PR TITLE
Fixed missing pushed objects in the HAR file

### DIFF
--- a/index.js
+++ b/index.js
@@ -651,7 +651,7 @@ module.exports = {
 
     if (!options.includeResourcesFromDiskCache) {
       entries = entries.filter(
-        entry => (entry.cache.beforeRequest === undefined || entry._was_pushed == 1)
+        entry => entry.cache.beforeRequest === undefined || entry._was_pushed == 1
       );
     }
 

--- a/index.js
+++ b/index.js
@@ -651,7 +651,7 @@ module.exports = {
 
     if (!options.includeResourcesFromDiskCache) {
       entries = entries.filter(
-        entry => ( entry.cache.beforeRequest === undefined  ||  entry._was_pushed == 1 )
+        entry => (entry.cache.beforeRequest === undefined || entry._was_pushed == 1)
       );
     }
 

--- a/index.js
+++ b/index.js
@@ -651,7 +651,7 @@ module.exports = {
 
     if (!options.includeResourcesFromDiskCache) {
       entries = entries.filter(
-        entry => entry.cache.beforeRequest === undefined
+        entry => ( entry.cache.beforeRequest === undefined  ||  entry._was_pushed == 1 )
       );
     }
 

--- a/index.js
+++ b/index.js
@@ -651,7 +651,8 @@ module.exports = {
 
     if (!options.includeResourcesFromDiskCache) {
       entries = entries.filter(
-        entry => entry.cache.beforeRequest === undefined || entry._was_pushed == 1
+        entry =>
+          entry.cache.beforeRequest === undefined || entry._was_pushed == 1
       );
     }
 


### PR DESCRIPTION
Hi,
I noticed that pushed H2 objects are often missing in the HAR file. I found the cause: lines 72-78 initialize the cache params for the pushed entry. As such, the object is considered as coming from the disk cache and not written in the HAR (line 654).
Adding the simple check that I propose solves the issue.