### PR TITLE
Support response bodies in HARs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,43 @@ Code originally extracted from [Browsertime](https://github.com/sitespeedio/brow
 
 [travis-image]: https://img.shields.io/travis/sitespeedio/chrome-har.svg?style=flat-square
 [travis-url]: https://travis-ci.org/sitespeedio/chrome-har
+
+## Support for Response Bodies
+
+Chrome-har optionally supports response bodies in HARs if they are set on the [response object](https://chromedevtools.github.io/devtools-protocol/tot/Network#type-Response) by the caller and if the `includeTextFromResponseBody` otpion is set to `true`.
+
+For example:
+```
+const harEvents: Array<any> = [];
+
+const HAR_OBSERVE_EVENTS = [
+  'Page.loadEventFired',
+  'Page.domContentEventFired',
+  'Page.frameStartedLoading',
+  'Page.frameAttached',
+  'Network.requestWillBeSent',
+  'Network.requestServedFromCache',
+  'Network.dataReceived',
+  'Network.responseReceived',
+  'Network.resourceChangedPriority',
+  'Network.loadingFinished',
+  'Network.loadingFailed',
+];
+
+HAR_OBSERVE_EVENTS.forEach((method: string) => {
+  client.on(method, async (params: any) => {
+    if (method === 'Network.requestIntercepted') {
+      const response = await client.send(
+        'Network.getResponseBodyForInterception',
+        { interceptionId: params.interceptionId },
+      );
+      // Set the body on the response object
+      params.response.body = response.body;
+      params.request.continue();
+    }
+    harEvents.push({ method, params });
+  });
+});
+
+const har = harFromMessages(harEvents, {includeTextFromResponseBody: true});
+```

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const populateEntryFromResponse = require('./lib/entryFromResponse');
 
 const defaultOptions = {
   includeResourcesFromDiskCache: false,
-  includeTextFromResponseBody: false,
+  includeTextFromResponseBody: false
 };
 const isEmpty = o => !o;
 
@@ -95,7 +95,12 @@ module.exports = {
                   entry => entry.__requestId === params.requestId
                 );
                 if (entry) {
-                  populateEntryFromResponse(entry, params.response, page, options);
+                  populateEntryFromResponse(
+                    entry,
+                    params.response,
+                    page,
+                    options
+                  );
                 } else {
                   debug(`Couln't find matching request for response`);
                 }
@@ -192,7 +197,7 @@ module.exports = {
                   previousEntry,
                   params.redirectResponse,
                   page,
-                  options,
+                  options
                 );
               } else {
                 debug(

--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ const {
 const populateEntryFromResponse = require('./lib/entryFromResponse');
 
 const defaultOptions = {
-  includeResourcesFromDiskCache: false
+  includeResourcesFromDiskCache: false,
+  includeTextFromResponseBody: false,
 };
 const isEmpty = o => !o;
 
@@ -94,7 +95,7 @@ module.exports = {
                   entry => entry.__requestId === params.requestId
                 );
                 if (entry) {
-                  populateEntryFromResponse(entry, params.response, page);
+                  populateEntryFromResponse(entry, params.response, page, options);
                 } else {
                   debug(`Couln't find matching request for response`);
                 }
@@ -190,7 +191,8 @@ module.exports = {
                 populateEntryFromResponse(
                   previousEntry,
                   params.redirectResponse,
-                  page
+                  page,
+                  options,
                 );
               } else {
                 debug(
@@ -300,7 +302,7 @@ module.exports = {
             }
 
             try {
-              populateEntryFromResponse(entry, params.response, page);
+              populateEntryFromResponse(entry, params.response, page, options);
             } catch (e) {
               debug(
                 `Error parsing response: ${JSON.stringify(

--- a/lib/entryFromResponse.js
+++ b/lib/entryFromResponse.js
@@ -26,9 +26,17 @@ function formatIP(ipAddress) {
   return ipAddress.replace(/^\[|]$/g, '');
 }
 
-module.exports = function(entry, response, page) {
+module.exports = function(entry, response, page, options) {
   const responseHeaders = response.headers;
   const cookieHeader = getHeaderValue(responseHeaders, 'Set-Cookie');
+
+  // response.body must be set by the library user, by either calling
+  // Network.getResponseBody or Network.getResponseBodyForInterception as it is
+  // not part of the Chrome DevTools Protocol specification.
+  // See https://chromedevtools.github.io/devtools-protocol/tot/Network#type-Response
+  const text = options != null && options.includeTextFromResponseBody ?
+               response.body :
+               undefined;
 
   entry.response = {
     httpVersion: response.protocol,
@@ -37,7 +45,8 @@ module.exports = function(entry, response, page) {
     statusText: response.statusText,
     content: {
       mimeType: response.mimeType,
-      size: 0
+      size: 0,
+      text: text,
     },
     headersSize: -1,
     bodySize: -1,

--- a/lib/entryFromResponse.js
+++ b/lib/entryFromResponse.js
@@ -34,9 +34,10 @@ module.exports = function(entry, response, page, options) {
   // Network.getResponseBody or Network.getResponseBodyForInterception as it is
   // not part of the Chrome DevTools Protocol specification.
   // See https://chromedevtools.github.io/devtools-protocol/tot/Network#type-Response
-  const text = options != null && options.includeTextFromResponseBody ?
-               response.body :
-               undefined;
+  const text =
+    options != null && options.includeTextFromResponseBody
+      ? response.body
+      : undefined;
 
   entry.response = {
     httpVersion: response.protocol,
@@ -46,7 +47,7 @@ module.exports = function(entry, response, page, options) {
     content: {
       mimeType: response.mimeType,
       size: 0,
-      text: text,
+      text: text
     },
     headersSize: -1,
     bodySize: -1,

--- a/test/perflogs/www.sitepeed.io.chrome66.json
+++ b/test/perflogs/www.sitepeed.io.chrome66.json
@@ -65,6 +65,7 @@
       "response": {
         "connectionId": 37,
         "connectionReused": false,
+        "body": "<!DOCTYPE HTML><HTML><BODY>Hello world</BODY></HTML>",
         "encodedDataLength": 262,
         "fromDiskCache": false,
         "fromServiceWorker": false,

--- a/test/tests.js
+++ b/test/tests.js
@@ -147,3 +147,11 @@ test('Includes pushed assets', t => {
       t.is(pushedImages.length, 3);
     });
 });
+
+test('Includes response bodies', t => {
+  const perflogPath = perflog('www.sitepeed.io.chrome66.json');
+  return parsePerflog(perflogPath, { includeTextFromResponseBody: true })
+    .then(har => har.log)
+    .tap(log => t.is(log.entries.filter(
+        e => e.response.content.text != null).length, 1));
+});

--- a/test/tests.js
+++ b/test/tests.js
@@ -152,6 +152,7 @@ test('Includes response bodies', t => {
   const perflogPath = perflog('www.sitepeed.io.chrome66.json');
   return parsePerflog(perflogPath, { includeTextFromResponseBody: true })
     .then(har => har.log)
-    .tap(log => t.is(log.entries.filter(
-        e => e.response.content.text != null).length, 1));
+    .tap(log =>
+      t.is(log.entries.filter(e => e.response.content.text != null).length, 1)
+    );
 });


### PR DESCRIPTION
Addresses #8 by setting `entry.response.content.text` to the `response.body` field within `populateEntryFromResponse`. Requires the user of the library to set the `response.body` themselves once the response has finished loading. 

Adds the `includeTextFromResponseBody`, so users can determine if they want the response body in the HARs, as these could significantly increase the size of the HARs. Defaults to `false.