### PR TITLE
Revert "Chrome dev tools cant parse resulting har file"

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ module.exports = {
               pageref: currentPageId,
               request: req,
               time: 0,
-              _initiator: params.initiator,
+              _initiator_detail: JSON.stringify(params.initiator),
               _initiator_type: params.initiator.type
             };
 
@@ -165,6 +165,7 @@ module.exports = {
             switch (params.initiator.type) {
               case 'parser':
                 {
+                  entry._initiator = params.initiator.url;
                   entry._initiator_line = params.initiator.lineNumber + 1; // Because lineNumber is 0 based
                 }
                 break;
@@ -176,6 +177,7 @@ module.exports = {
                     params.initiator.stack.callFrames.length > 0
                   ) {
                     const topCallFrame = params.initiator.stack.callFrames[0];
+                    entry._initiator = topCallFrame.url;
                     entry._initiator_line = topCallFrame.lineNumber + 1; // Because lineNumber is 0 based
                     entry._initiator_column = topCallFrame.columnNumber + 1; // Because columnNumber is 0 based
                     entry._initiator_function_name = topCallFrame.functionName;


### PR DESCRIPTION
Reverts sitespeedio/chrome-har#44

I didn't look to much at this: It's clearly a fix for broken puppeteer and it breaks things for the raw trace from Chrome. Lets revert and then we can add better checks that fields really exists.