### PR TITLE
Fix missing initial redirects

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,15 +188,17 @@ module.exports = {
             }
 
             if (params.redirectResponse) {
-              const previousEntry = entries.find(
+              const previousEntry = entries.concat(entriesWithoutPage).find(
                 entry => entry._requestId === params.requestId
               );
+              const timings = page || {}
+              addFromFirstRequest(timings,params)
               if (previousEntry) {
                 previousEntry._requestId += 'r';
                 populateEntryFromResponse(
                   previousEntry,
                   params.redirectResponse,
-                  page,
+                  timings,
                   options
                 );
               } else {

--- a/index.js
+++ b/index.js
@@ -188,11 +188,11 @@ module.exports = {
             }
 
             if (params.redirectResponse) {
-              const previousEntry = entries.concat(entriesWithoutPage).find(
-                entry => entry._requestId === params.requestId
-              );
+              const previousEntry = entries
+                .concat(entriesWithoutPage)
+                .find(entry => entry._requestId === params.requestId);
               const timings = page || {};
-              addFromFirstRequest(timings,params);
+              addFromFirstRequest(timings, params);
               if (previousEntry) {
                 previousEntry._requestId += 'r';
                 populateEntryFromResponse(

--- a/index.js
+++ b/index.js
@@ -191,8 +191,8 @@ module.exports = {
               const previousEntry = entries.concat(entriesWithoutPage).find(
                 entry => entry._requestId === params.requestId
               );
-              const timings = page || {}
-              addFromFirstRequest(timings,params)
+              const timings = page || {};
+              addFromFirstRequest(timings,params);
               if (previousEntry) {
                 previousEntry._requestId += 'r';
                 populateEntryFromResponse(


### PR DESCRIPTION
Prior to this change redirects which occur before the first page navigation are lost. 
I had to add `addFromFirstRequest(timings,params)` to ensure timing information would be passed to `populateEntryFromResponse`.  This could probably written more clearly but would require refactoring of the timing/page logic.

