### PR TITLE
Parse extra info events

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,22 +1,22 @@
-'use strict';
+"use strict";
 
-const { name, version, homepage } = require('./package');
+const { name, version, homepage } = require("./package");
 
-const urlParser = require('url');
-const { v1 } = require('uuid');
-const dayjs = require('dayjs');
-const debug = require('debug')(name);
-const ignoredEvents = require('./lib/ignoredEvents');
-const { parseRequestCookies } = require('./lib/cookies');
-const { getHeaderValue, parseHeaders } = require('./lib/headers');
+const urlParser = require("url");
+const { v1 } = require("uuid");
+const dayjs = require("dayjs");
+const debug = require("debug")(name);
+const ignoredEvents = require("./lib/ignoredEvents");
+const { parseRequestCookies, formatCookie } = require("./lib/cookies");
+const { getHeaderValue, parseHeaders } = require("./lib/headers");
 const {
   formatMillis,
   parsePostData,
   isSupportedProtocol,
   toNameValuePairs
-} = require('./lib/util');
-const populateEntryFromResponse = require('./lib/entryFromResponse');
-const finalizeEntry = require('./lib/finalizeEntry');
+} = require("./lib/util");
+const populateEntryFromResponse = require("./lib/entryFromResponse");
+const finalizeEntry = require("./lib/finalizeEntry");
 
 const defaultOptions = {
   includeResourcesFromDiskCache: false,
@@ -30,7 +30,7 @@ function addFromFirstRequest(page, params) {
     page.__timestamp = params.timestamp;
     page.startedDateTime = dayjs.unix(params.wallTime).toISOString(); //epoch float64, eg 1440589909.59248
     // URL is better than blank, and it's what devtools uses.
-    page.title = page.title === '' ? params.request.url : page.title;
+    page.title = page.title === "" ? params.request.url : page.title;
   }
 }
 
@@ -58,9 +58,9 @@ module.exports = {
       }
 
       switch (method) {
-        case 'Page.frameStartedLoading':
-        case 'Page.frameScheduledNavigation':
-        case 'Page.navigatedWithinDocument':
+        case "Page.frameStartedLoading":
+        case "Page.frameScheduledNavigation":
+        case "Page.navigatedWithinDocument":
           {
             const frameId = params.frameId;
             const rootFrame = rootFrameMappings.get(frameId) || frameId;
@@ -69,10 +69,10 @@ module.exports = {
             }
             currentPageId = v1();
             const title =
-              method === 'Page.navigatedWithinDocument' ? params.url : '';
+              method === "Page.navigatedWithinDocument" ? params.url : "";
             const page = {
               id: currentPageId,
-              startedDateTime: '',
+              startedDateTime: "",
               title: title,
               pageTimings: {},
               __frameId: rootFrame
@@ -107,7 +107,7 @@ module.exports = {
           }
           break;
 
-        case 'Network.requestWillBeSent':
+        case "Network.requestWillBeSent":
           {
             const request = params.request;
             if (!isSupportedProtocol(request.url)) {
@@ -115,7 +115,7 @@ module.exports = {
               continue;
             }
             const page = pages[pages.length - 1];
-            const cookieHeader = getHeaderValue(request.headers, 'Cookie');
+            const cookieHeader = getHeaderValue(request.headers, "Cookie");
 
             //Before we used to remove the hash framgment because of Chrome do that but:
             // 1. Firefox do not
@@ -123,12 +123,12 @@ module.exports = {
             // and that makes PageXray generate the wromng URL and we end up with two pages
             // in sitespeed.io if we run in SPA mode
             const url = urlParser.parse(
-              request.url + (request.urlFragment ? request.urlFragment : ''),
+              request.url + (request.urlFragment ? request.urlFragment : ""),
               true
             );
 
             const postData = parsePostData(
-              getHeaderValue(request.headers, 'Content-Type'),
+              getHeaderValue(request.headers, "Content-Type"),
               request.postData
             );
 
@@ -145,7 +145,7 @@ module.exports = {
 
             const entry = {
               cache: {},
-              startedDateTime: '',
+              startedDateTime: "",
               __requestWillBeSentTime: params.timestamp,
               __wallTime: params.wallTime,
               _requestId: params.requestId,
@@ -161,14 +161,14 @@ module.exports = {
 
             // The object initiator change according to its type
             switch (params.initiator.type) {
-              case 'parser':
+              case "parser":
                 {
                   entry._initiator = params.initiator.url;
                   entry._initiator_line = params.initiator.lineNumber + 1; // Because lineNumber is 0 based
                 }
                 break;
 
-              case 'script':
+              case "script":
                 {
                   if (
                     params.initiator.stack &&
@@ -190,7 +190,7 @@ module.exports = {
                 entry => entry._requestId === params.requestId
               );
               if (previousEntry) {
-                previousEntry._requestId += 'r';
+                previousEntry._requestId += "r";
                 populateEntryFromResponse(
                   previousEntry,
                   params.redirectResponse,
@@ -230,7 +230,7 @@ module.exports = {
           }
           break;
 
-        case 'Network.requestServedFromCache':
+        case "Network.requestServedFromCache":
           {
             if (pages.length < 1) {
               //we haven't loaded any pages yet.
@@ -255,14 +255,44 @@ module.exports = {
 
             entry.__servedFromCache = true;
             entry.cache.beforeRequest = {
-              lastAccess: '',
-              eTag: '',
+              lastAccess: "",
+              eTag: "",
               hitCount: 0
             };
           }
           break;
 
-        case 'Network.responseReceived':
+        case "Network.requestWillBeSentExtraInfo":
+          {
+            const entry = entries.find(
+              entry => entry._requestId === params.requestId
+            );
+            if (!entry) {
+              debug(
+                `Extra info sent for requestId ${
+                  params.requestId
+                } with no matching request.`
+              );
+              continue;
+            }
+
+            if (params.headers) {
+              entry.request.headers = entry.request.headers.concat(
+                parseHeaders(params.headers)
+              );
+            }
+
+            if (params.associatedCookies) {
+              entry.request.cookies = (entry.request.cookies || []).concat(
+                params.associatedCookies.map(({ cookie }) =>
+                  formatCookie(cookie)
+                )
+              );
+            }
+          }
+          break;
+
+        case "Network.responseReceived":
           {
             if (pages.length < 1) {
               //we haven't loaded any pages yet.
@@ -321,7 +351,7 @@ module.exports = {
           }
           break;
 
-        case 'Network.dataReceived':
+        case "Network.dataReceived":
           {
             if (pages.length < 1) {
               //we haven't loaded any pages yet.
@@ -351,7 +381,7 @@ module.exports = {
           }
           break;
 
-        case 'Network.loadingFinished':
+        case "Network.loadingFinished":
           {
             if (pages.length < 1) {
               //we haven't loaded any pages yet.
@@ -378,7 +408,7 @@ module.exports = {
           }
           break;
 
-        case 'Page.loadEventFired':
+        case "Page.loadEventFired":
           {
             if (pages.length < 1) {
               //we haven't loaded any pages yet.
@@ -395,7 +425,7 @@ module.exports = {
           }
           break;
 
-        case 'Page.domContentEventFired':
+        case "Page.domContentEventFired":
           {
             if (pages.length < 1) {
               //we haven't loaded any pages yet.
@@ -412,7 +442,7 @@ module.exports = {
           }
           break;
 
-        case 'Page.frameAttached':
+        case "Page.frameAttached":
           {
             const frameId = params.frameId,
               parentId = params.parentFrameId;
@@ -427,7 +457,7 @@ module.exports = {
           }
           break;
 
-        case 'Network.loadingFailed':
+        case "Network.loadingFailed":
           {
             if (ignoredRequests.has(params.requestId)) {
               ignoredRequests.delete(params.requestId);
@@ -446,7 +476,7 @@ module.exports = {
               continue;
             }
 
-            if (params.errorText === 'net::ERR_ABORTED') {
+            if (params.errorText === "net::ERR_ABORTED") {
               finalizeEntry(entry, params);
               debug(
                 `Loading was canceled due to Chrome or a user action for requestId ${
@@ -469,7 +499,7 @@ module.exports = {
           }
           break;
 
-        case 'Network.resourceChangedPriority':
+        case "Network.resourceChangedPriority":
           {
             const entry = entries.find(
               entry => entry._requestId === params.requestId
@@ -504,7 +534,7 @@ module.exports = {
     const deleteInternalProperties = o => {
       // __ properties are only for internal use, _ properties are custom properties for the HAR
       for (const prop in o) {
-        if (prop.startsWith('__')) {
+        if (prop.startsWith("__")) {
           delete o[prop];
         }
       }
@@ -547,7 +577,7 @@ module.exports = {
 
     return {
       log: {
-        version: '1.2',
+        version: "1.2",
         creator: { name, version, comment: homepage },
         pages,
         entries

--- a/index.js
+++ b/index.js
@@ -1,22 +1,22 @@
-"use strict";
+'use strict';
 
-const { name, version, homepage } = require("./package");
+const { name, version, homepage } = require('./package');
 
-const urlParser = require("url");
-const { v1 } = require("uuid");
-const dayjs = require("dayjs");
-const debug = require("debug")(name);
-const ignoredEvents = require("./lib/ignoredEvents");
-const { parseRequestCookies, formatCookie } = require("./lib/cookies");
-const { getHeaderValue, parseHeaders } = require("./lib/headers");
+const urlParser = require('url');
+const { v1 } = require('uuid');
+const dayjs = require('dayjs');
+const debug = require('debug')(name);
+const ignoredEvents = require('./lib/ignoredEvents');
+const { parseRequestCookies, formatCookie } = require('./lib/cookies');
+const { getHeaderValue, parseHeaders } = require('./lib/headers');
 const {
   formatMillis,
   parsePostData,
   isSupportedProtocol,
   toNameValuePairs
-} = require("./lib/util");
-const populateEntryFromResponse = require("./lib/entryFromResponse");
-const finalizeEntry = require("./lib/finalizeEntry");
+} = require('./lib/util');
+const populateEntryFromResponse = require('./lib/entryFromResponse');
+const finalizeEntry = require('./lib/finalizeEntry');
 
 const defaultOptions = {
   includeResourcesFromDiskCache: false,
@@ -30,7 +30,7 @@ function addFromFirstRequest(page, params) {
     page.__timestamp = params.timestamp;
     page.startedDateTime = dayjs.unix(params.wallTime).toISOString(); //epoch float64, eg 1440589909.59248
     // URL is better than blank, and it's what devtools uses.
-    page.title = page.title === "" ? params.request.url : page.title;
+    page.title = page.title === '' ? params.request.url : page.title;
   }
 }
 
@@ -58,9 +58,9 @@ module.exports = {
       }
 
       switch (method) {
-        case "Page.frameStartedLoading":
-        case "Page.frameScheduledNavigation":
-        case "Page.navigatedWithinDocument":
+        case 'Page.frameStartedLoading':
+        case 'Page.frameScheduledNavigation':
+        case 'Page.navigatedWithinDocument':
           {
             const frameId = params.frameId;
             const rootFrame = rootFrameMappings.get(frameId) || frameId;
@@ -69,10 +69,10 @@ module.exports = {
             }
             currentPageId = v1();
             const title =
-              method === "Page.navigatedWithinDocument" ? params.url : "";
+              method === 'Page.navigatedWithinDocument' ? params.url : '';
             const page = {
               id: currentPageId,
-              startedDateTime: "",
+              startedDateTime: '',
               title: title,
               pageTimings: {},
               __frameId: rootFrame
@@ -107,7 +107,7 @@ module.exports = {
           }
           break;
 
-        case "Network.requestWillBeSent":
+        case 'Network.requestWillBeSent':
           {
             const request = params.request;
             if (!isSupportedProtocol(request.url)) {
@@ -115,7 +115,7 @@ module.exports = {
               continue;
             }
             const page = pages[pages.length - 1];
-            const cookieHeader = getHeaderValue(request.headers, "Cookie");
+            const cookieHeader = getHeaderValue(request.headers, 'Cookie');
 
             //Before we used to remove the hash framgment because of Chrome do that but:
             // 1. Firefox do not
@@ -123,12 +123,12 @@ module.exports = {
             // and that makes PageXray generate the wromng URL and we end up with two pages
             // in sitespeed.io if we run in SPA mode
             const url = urlParser.parse(
-              request.url + (request.urlFragment ? request.urlFragment : ""),
+              request.url + (request.urlFragment ? request.urlFragment : ''),
               true
             );
 
             const postData = parsePostData(
-              getHeaderValue(request.headers, "Content-Type"),
+              getHeaderValue(request.headers, 'Content-Type'),
               request.postData
             );
 
@@ -145,7 +145,7 @@ module.exports = {
 
             const entry = {
               cache: {},
-              startedDateTime: "",
+              startedDateTime: '',
               __requestWillBeSentTime: params.timestamp,
               __wallTime: params.wallTime,
               _requestId: params.requestId,
@@ -161,14 +161,14 @@ module.exports = {
 
             // The object initiator change according to its type
             switch (params.initiator.type) {
-              case "parser":
+              case 'parser':
                 {
                   entry._initiator = params.initiator.url;
                   entry._initiator_line = params.initiator.lineNumber + 1; // Because lineNumber is 0 based
                 }
                 break;
 
-              case "script":
+              case 'script':
                 {
                   if (
                     params.initiator.stack &&
@@ -190,7 +190,7 @@ module.exports = {
                 entry => entry._requestId === params.requestId
               );
               if (previousEntry) {
-                previousEntry._requestId += "r";
+                previousEntry._requestId += 'r';
                 populateEntryFromResponse(
                   previousEntry,
                   params.redirectResponse,
@@ -230,7 +230,7 @@ module.exports = {
           }
           break;
 
-        case "Network.requestServedFromCache":
+        case 'Network.requestServedFromCache':
           {
             if (pages.length < 1) {
               //we haven't loaded any pages yet.
@@ -255,14 +255,14 @@ module.exports = {
 
             entry.__servedFromCache = true;
             entry.cache.beforeRequest = {
-              lastAccess: "",
-              eTag: "",
+              lastAccess: '',
+              eTag: '',
               hitCount: 0
             };
           }
           break;
 
-        case "Network.requestWillBeSentExtraInfo":
+        case 'Network.requestWillBeSentExtraInfo':
           {
             if (ignoredRequests.has(params.requestId)) {
               continue;
@@ -296,7 +296,7 @@ module.exports = {
           }
           break;
 
-        case "Network.responseReceivedExtraInfo":
+        case 'Network.responseReceivedExtraInfo':
           {
             if (pages.length < 1) {
               //we haven't loaded any pages yet.
@@ -343,7 +343,7 @@ module.exports = {
           }
           break;
 
-        case "Network.responseReceived":
+        case 'Network.responseReceived':
           {
             if (pages.length < 1) {
               //we haven't loaded any pages yet.
@@ -403,7 +403,7 @@ module.exports = {
           }
           break;
 
-        case "Network.dataReceived":
+        case 'Network.dataReceived':
           {
             if (pages.length < 1) {
               //we haven't loaded any pages yet.
@@ -433,7 +433,7 @@ module.exports = {
           }
           break;
 
-        case "Network.loadingFinished":
+        case 'Network.loadingFinished':
           {
             if (pages.length < 1) {
               //we haven't loaded any pages yet.
@@ -460,7 +460,7 @@ module.exports = {
           }
           break;
 
-        case "Page.loadEventFired":
+        case 'Page.loadEventFired':
           {
             if (pages.length < 1) {
               //we haven't loaded any pages yet.
@@ -477,7 +477,7 @@ module.exports = {
           }
           break;
 
-        case "Page.domContentEventFired":
+        case 'Page.domContentEventFired':
           {
             if (pages.length < 1) {
               //we haven't loaded any pages yet.
@@ -494,7 +494,7 @@ module.exports = {
           }
           break;
 
-        case "Page.frameAttached":
+        case 'Page.frameAttached':
           {
             const frameId = params.frameId,
               parentId = params.parentFrameId;
@@ -509,7 +509,7 @@ module.exports = {
           }
           break;
 
-        case "Network.loadingFailed":
+        case 'Network.loadingFailed':
           {
             if (ignoredRequests.has(params.requestId)) {
               ignoredRequests.delete(params.requestId);
@@ -528,7 +528,7 @@ module.exports = {
               continue;
             }
 
-            if (params.errorText === "net::ERR_ABORTED") {
+            if (params.errorText === 'net::ERR_ABORTED') {
               finalizeEntry(entry, params);
               debug(
                 `Loading was canceled due to Chrome or a user action for requestId ${
@@ -551,7 +551,7 @@ module.exports = {
           }
           break;
 
-        case "Network.resourceChangedPriority":
+        case 'Network.resourceChangedPriority':
           {
             const entry = entries.find(
               entry => entry._requestId === params.requestId
@@ -586,7 +586,7 @@ module.exports = {
     const deleteInternalProperties = o => {
       // __ properties are only for internal use, _ properties are custom properties for the HAR
       for (const prop in o) {
-        if (prop.startsWith("__")) {
+        if (prop.startsWith('__')) {
           delete o[prop];
         }
       }
@@ -629,7 +629,7 @@ module.exports = {
 
     return {
       log: {
-        version: "1.2",
+        version: '1.2',
         creator: { name, version, comment: homepage },
         pages,
         entries

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -1,5 +1,20 @@
-const Cookie = require('tough-cookie').Cookie;
-const dayjs = require('dayjs');
+const Cookie = require("tough-cookie").Cookie;
+const dayjs = require("dayjs");
+
+function formatCookie(cookie) {
+  return {
+    name: cookie.key || cookie.name,
+    value: cookie.value,
+    path: cookie.path || undefined, // must be undefined, not null, to exclude empty path
+    domain: cookie.domain || undefined, // must be undefined, not null, to exclude empty domain
+    expires:
+      cookie.expires === "Infinity"
+        ? undefined
+        : dayjs(cookie.expires).toISOString(),
+    httpOnly: cookie.httpOnly,
+    secure: cookie.secure
+  };
+}
 
 function parseCookie(cookieString) {
   let cookie = Cookie.parse(cookieString);
@@ -7,18 +22,7 @@ function parseCookie(cookieString) {
     return undefined;
   }
 
-  return {
-    name: cookie.key,
-    value: cookie.value,
-    path: cookie.path || undefined, // must be undefined, not null, to exclude empty path
-    domain: cookie.domain || undefined, // must be undefined, not null, to exclude empty domain
-    expires:
-      cookie.expires === 'Infinity'
-        ? undefined
-        : dayjs(cookie.expires).toISOString(),
-    httpOnly: cookie.httpOnly,
-    secure: cookie.secure
-  };
+  return formatCookie(cookie);
 }
 
 function splitAndParse(header, divider) {
@@ -31,9 +35,10 @@ function splitAndParse(header, divider) {
 
 module.exports = {
   parseRequestCookies(cookieHeader) {
-    return splitAndParse(cookieHeader, ';');
+    return splitAndParse(cookieHeader, ";");
   },
   parseResponseCookies(cookieHeader) {
-    return splitAndParse(cookieHeader, '\n');
-  }
+    return splitAndParse(cookieHeader, "\n");
+  },
+  formatCookie
 };

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -1,5 +1,5 @@
-const Cookie = require("tough-cookie").Cookie;
-const dayjs = require("dayjs");
+const Cookie = require('tough-cookie').Cookie;
+const dayjs = require('dayjs');
 
 function formatCookie(cookie) {
   return {
@@ -8,7 +8,7 @@ function formatCookie(cookie) {
     path: cookie.path || undefined, // must be undefined, not null, to exclude empty path
     domain: cookie.domain || undefined, // must be undefined, not null, to exclude empty domain
     expires:
-      cookie.expires === "Infinity"
+      cookie.expires === 'Infinity'
         ? undefined
         : dayjs(cookie.expires).toISOString(),
     httpOnly: cookie.httpOnly,
@@ -35,10 +35,10 @@ function splitAndParse(header, divider) {
 
 module.exports = {
   parseRequestCookies(cookieHeader) {
-    return splitAndParse(cookieHeader, ";");
+    return splitAndParse(cookieHeader, ';');
   },
   parseResponseCookies(cookieHeader) {
-    return splitAndParse(cookieHeader, "\n");
+    return splitAndParse(cookieHeader, '\n');
   },
   formatCookie
 };

--- a/lib/entryFromResponse.js
+++ b/lib/entryFromResponse.js
@@ -1,5 +1,5 @@
-'use strict';
-const dayjs = require('dayjs');
+"use strict";
+const dayjs = require("dayjs");
 const max = Math.max;
 
 const {
@@ -7,10 +7,10 @@ const {
   calculateResponseHeaderSize,
   getHeaderValue,
   parseHeaders
-} = require('./headers');
+} = require("./headers");
 
-const { parseRequestCookies, parseResponseCookies } = require('./cookies');
-const { isHttp1x, formatMillis } = require('./util');
+const { parseRequestCookies, parseResponseCookies } = require("./cookies");
+const { isHttp1x, formatMillis } = require("./util");
 function firstNonNegative(values) {
   for (let i = 0; i < values.length; ++i) {
     if (values[i] >= 0) return values[i];
@@ -19,16 +19,41 @@ function firstNonNegative(values) {
 }
 
 function formatIP(ipAddress) {
-  if (typeof ipAddress !== 'string') {
+  if (typeof ipAddress !== "string") {
     return undefined;
   }
   // IPv6 addresses are listed as [2a00:1450:400f:80a::2003]
-  return ipAddress.replace(/^\[|]$/g, '');
+  return ipAddress.replace(/^\[|]$/g, "");
 }
 
 module.exports = function(entry, response, page, options) {
   const responseHeaders = response.headers;
-  const cookieHeader = getHeaderValue(responseHeaders, 'Set-Cookie');
+  const cookieHeader = getHeaderValue(responseHeaders, "Set-Cookie");
+
+  let cookies = parseResponseCookies(cookieHeader);
+  let headers = parseHeaders(responseHeaders);
+
+  if (entry.extraResponseInfo) {
+    if (entry.extraResponseInfo.headers) {
+      headers = entry.extraResponseInfo.headers.concat(
+        headers.filter(
+          ({ name }) => !headers.find(header => header.name === name)
+        )
+      );
+    }
+
+    if (entry.extraResponseInfo.blockedCookies) {
+      cookies = cookies.filter(
+        ({ name }) =>
+          !entry.extraResponseInfo.blockedCookies.find(
+            ({ cookie }) => cookie.name === name
+          )
+      );
+    }
+
+    // Remove extra info once it has been added to the response
+    delete entry.extraResponseInfo;
+  }
 
   // response.body must be set by the library user, by either calling
   // Network.getResponseBody or Network.getResponseBodyForInterception as it is
@@ -41,7 +66,7 @@ module.exports = function(entry, response, page, options) {
 
   entry.response = {
     httpVersion: response.protocol,
-    redirectURL: '',
+    redirectURL: "",
     status: response.status,
     statusText: response.statusText,
     content: {
@@ -51,12 +76,12 @@ module.exports = function(entry, response, page, options) {
     },
     headersSize: -1,
     bodySize: -1,
-    cookies: parseResponseCookies(cookieHeader),
-    headers: parseHeaders(responseHeaders),
+    cookies,
+    headers,
     _transferSize: response.encodedDataLength
   };
 
-  const locationHeaderValue = getHeaderValue(responseHeaders, 'Location');
+  const locationHeaderValue = getHeaderValue(responseHeaders, "Location");
   if (locationHeaderValue) {
     entry.response.redirectURL = locationHeaderValue;
   }
@@ -72,8 +97,8 @@ module.exports = function(entry, response, page, options) {
     // h2 push might cause resource to be received before parser sees and requests it.
     if (response.timing && !(response.timing.pushStart > 0)) {
       entry.cache.beforeRequest = {
-        lastAccess: '',
-        eTag: '',
+        lastAccess: "",
+        eTag: "",
         hitCount: 0
       };
     }
@@ -81,7 +106,7 @@ module.exports = function(entry, response, page, options) {
     if (response.requestHeaders) {
       entry.request.headers = parseHeaders(response.requestHeaders);
 
-      const cookieHeader = getHeaderValue(response.requestHeaders, 'Cookie');
+      const cookieHeader = getHeaderValue(response.requestHeaders, "Cookie");
       entry.request.cookies = parseRequestCookies(cookieHeader);
     }
 
@@ -120,13 +145,13 @@ module.exports = function(entry, response, page, options) {
       firstNonNegative([timing.dnsStart, timing.connectStart, timing.sendStart])
     );
 
-    const dns = parseOptionalTime(timing, 'dnsStart', 'dnsEnd');
-    const connect = parseOptionalTime(timing, 'connectStart', 'connectEnd');
+    const dns = parseOptionalTime(timing, "dnsStart", "dnsEnd");
+    const connect = parseOptionalTime(timing, "connectStart", "connectEnd");
     const send = formatMillis(timing.sendEnd - timing.sendStart);
     const wait = formatMillis(timing.receiveHeadersEnd - timing.sendEnd);
     const receive = 0;
 
-    const ssl = parseOptionalTime(timing, 'sslStart', 'sslEnd');
+    const ssl = parseOptionalTime(timing, "sslStart", "sslEnd");
 
     entry.timings = {
       blocked,
@@ -177,7 +202,7 @@ module.exports = function(entry, response, page, options) {
       wait: 0,
       receive: 0,
       ssl: -1,
-      comment: 'No timings available from Chrome'
+      comment: "No timings available from Chrome"
     };
     entry.time = 0;
   }

--- a/lib/entryFromResponse.js
+++ b/lib/entryFromResponse.js
@@ -1,5 +1,5 @@
-"use strict";
-const dayjs = require("dayjs");
+'use strict';
+const dayjs = require('dayjs');
 const max = Math.max;
 
 const {
@@ -7,10 +7,10 @@ const {
   calculateResponseHeaderSize,
   getHeaderValue,
   parseHeaders
-} = require("./headers");
+} = require('./headers');
 
-const { parseRequestCookies, parseResponseCookies } = require("./cookies");
-const { isHttp1x, formatMillis } = require("./util");
+const { parseRequestCookies, parseResponseCookies } = require('./cookies');
+const { isHttp1x, formatMillis } = require('./util');
 function firstNonNegative(values) {
   for (let i = 0; i < values.length; ++i) {
     if (values[i] >= 0) return values[i];
@@ -19,16 +19,16 @@ function firstNonNegative(values) {
 }
 
 function formatIP(ipAddress) {
-  if (typeof ipAddress !== "string") {
+  if (typeof ipAddress !== 'string') {
     return undefined;
   }
   // IPv6 addresses are listed as [2a00:1450:400f:80a::2003]
-  return ipAddress.replace(/^\[|]$/g, "");
+  return ipAddress.replace(/^\[|]$/g, '');
 }
 
 module.exports = function(entry, response, page, options) {
   const responseHeaders = response.headers;
-  const cookieHeader = getHeaderValue(responseHeaders, "Set-Cookie");
+  const cookieHeader = getHeaderValue(responseHeaders, 'Set-Cookie');
 
   let cookies = parseResponseCookies(cookieHeader);
   let headers = parseHeaders(responseHeaders);
@@ -66,7 +66,7 @@ module.exports = function(entry, response, page, options) {
 
   entry.response = {
     httpVersion: response.protocol,
-    redirectURL: "",
+    redirectURL: '',
     status: response.status,
     statusText: response.statusText,
     content: {
@@ -81,7 +81,7 @@ module.exports = function(entry, response, page, options) {
     _transferSize: response.encodedDataLength
   };
 
-  const locationHeaderValue = getHeaderValue(responseHeaders, "Location");
+  const locationHeaderValue = getHeaderValue(responseHeaders, 'Location');
   if (locationHeaderValue) {
     entry.response.redirectURL = locationHeaderValue;
   }
@@ -97,8 +97,8 @@ module.exports = function(entry, response, page, options) {
     // h2 push might cause resource to be received before parser sees and requests it.
     if (response.timing && !(response.timing.pushStart > 0)) {
       entry.cache.beforeRequest = {
-        lastAccess: "",
-        eTag: "",
+        lastAccess: '',
+        eTag: '',
         hitCount: 0
       };
     }
@@ -106,7 +106,7 @@ module.exports = function(entry, response, page, options) {
     if (response.requestHeaders) {
       entry.request.headers = parseHeaders(response.requestHeaders);
 
-      const cookieHeader = getHeaderValue(response.requestHeaders, "Cookie");
+      const cookieHeader = getHeaderValue(response.requestHeaders, 'Cookie');
       entry.request.cookies = parseRequestCookies(cookieHeader);
     }
 
@@ -145,13 +145,13 @@ module.exports = function(entry, response, page, options) {
       firstNonNegative([timing.dnsStart, timing.connectStart, timing.sendStart])
     );
 
-    const dns = parseOptionalTime(timing, "dnsStart", "dnsEnd");
-    const connect = parseOptionalTime(timing, "connectStart", "connectEnd");
+    const dns = parseOptionalTime(timing, 'dnsStart', 'dnsEnd');
+    const connect = parseOptionalTime(timing, 'connectStart', 'connectEnd');
     const send = formatMillis(timing.sendEnd - timing.sendStart);
     const wait = formatMillis(timing.receiveHeadersEnd - timing.sendEnd);
     const receive = 0;
 
-    const ssl = parseOptionalTime(timing, "sslStart", "sslEnd");
+    const ssl = parseOptionalTime(timing, 'sslStart', 'sslEnd');
 
     entry.timings = {
       blocked,
@@ -202,7 +202,7 @@ module.exports = function(entry, response, page, options) {
       wait: 0,
       receive: 0,
       ssl: -1,
-      comment: "No timings available from Chrome"
+      comment: 'No timings available from Chrome'
     };
     entry.time = 0;
   }

--- a/lib/finalizeEntry.js
+++ b/lib/finalizeEntry.js
@@ -1,4 +1,4 @@
-const { isHttp1x, formatMillis } = require('./util');
+const { isHttp1x, formatMillis } = require("./util");
 
 const max = Math.max;
 

--- a/lib/finalizeEntry.js
+++ b/lib/finalizeEntry.js
@@ -1,4 +1,4 @@
-const { isHttp1x, formatMillis } = require("./util");
+const { isHttp1x, formatMillis } = require('./util');
 
 const max = Math.max;
 

--- a/test/perflogs/response-blocked-cookies.json
+++ b/test/perflogs/response-blocked-cookies.json
@@ -1,0 +1,1414 @@
+[
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "0394D4840FF578F1B713EAF43C75D15C",
+      "name": "commit",
+      "timestamp": 105304.825458
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "0394D4840FF578F1B713EAF43C75D15C",
+      "name": "DOMContentLoaded",
+      "timestamp": 105304.825701
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "0394D4840FF578F1B713EAF43C75D15C",
+      "name": "load",
+      "timestamp": 105304.826454
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "0394D4840FF578F1B713EAF43C75D15C",
+      "name": "networkAlmostIdle",
+      "timestamp": 105304.827428
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "0394D4840FF578F1B713EAF43C75D15C",
+      "name": "networkIdle",
+      "timestamp": 105304.827428
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "documentURL": "https://1j7om.csb.app/",
+      "request": {
+        "url": "https://1j7om.csb.app/",
+        "method": "GET",
+        "headers": {
+          "Upgrade-Insecure-Requests": "1",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 105304.900271,
+      "wallTime": 1595998349.332865,
+      "initiator": { "type": "other" },
+      "type": "Document",
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "associatedCookies": [],
+      "headers": {
+        ":method": "GET",
+        ":authority": "1j7om.csb.app",
+        ":scheme": "https",
+        ":path": "/",
+        "upgrade-insecure-requests": "1",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept":
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+        "sec-fetch-site": "none",
+        "sec-fetch-mode": "navigate",
+        "sec-fetch-user": "?1",
+        "sec-fetch-dest": "document",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "date": "Wed, 29 Jul 2020 04:52:29 GMT",
+        "content-type": "text/html",
+        "set-cookie":
+          "__cfduid=da0f64c008e4700b2ef1278a954bbfaab1595998349; expires=Fri, 28-Aug-20 04:52:29 GMT; path=/; domain=.csb.app; HttpOnly; SameSite=Lax\nsignedIn=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; max-age=0; HttpOnly",
+        "vary": "Accept-Encoding",
+        "cache-control": "private, max-age=0, no-cache, no-store",
+        "x-request-id": "FiYgCwONI2AAty-jgboB",
+        "via": "1.1 google",
+        "alt-svc":
+          "h3-27=\":443\"; ma=86400, h3-28=\":443\"; ma=86400, h3-29=\":443\"; ma=86400",
+        "cf-cache-status": "DYNAMIC",
+        "cf-request-id": "043a83409e000016c9312cf200000001",
+        "expect-ct":
+          "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+        "server": "cloudflare",
+        "cf-ray": "5ba43b1438bf16c9-SYD",
+        "content-encoding": "br"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "timestamp": 105305.274595,
+      "type": "Document",
+      "response": {
+        "url": "https://1j7om.csb.app/",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "status": "200",
+          "date": "Wed, 29 Jul 2020 04:52:29 GMT",
+          "content-type": "text/html",
+          "set-cookie":
+            "__cfduid=da0f64c008e4700b2ef1278a954bbfaab1595998349; expires=Fri, 28-Aug-20 04:52:29 GMT; path=/; domain=.csb.app; HttpOnly; SameSite=Lax\nsignedIn=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; max-age=0; HttpOnly",
+          "vary": "Accept-Encoding",
+          "cache-control": "private, max-age=0, no-cache, no-store",
+          "x-request-id": "FiYgCwONI2AAty-jgboB",
+          "via": "1.1 google",
+          "alt-svc":
+            "h3-27=\":443\"; ma=86400, h3-28=\":443\"; ma=86400, h3-29=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-request-id": "043a83409e000016c9312cf200000001",
+          "expect-ct":
+            "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+          "server": "cloudflare",
+          "cf-ray": "5ba43b1438bf16c9-SYD",
+          "content-encoding": "br"
+        },
+        "mimeType": "text/html",
+        "requestHeaders": {
+          ":method": "GET",
+          ":authority": "1j7om.csb.app",
+          ":scheme": "https",
+          ":path": "/",
+          "upgrade-insecure-requests": "1",
+          "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+          "accept":
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+          "sec-fetch-site": "none",
+          "sec-fetch-mode": "navigate",
+          "sec-fetch-user": "?1",
+          "sec-fetch-dest": "document",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+        },
+        "connectionReused": false,
+        "connectionId": 27,
+        "remoteIPAddress": "104.18.26.114",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 517,
+        "timing": {
+          "requestTime": 105304.900931,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.201,
+          "dnsEnd": 18.829,
+          "connectStart": 18.829,
+          "connectEnd": 59.169,
+          "sslStart": 32.295,
+          "sslEnd": 59.124,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 60.098,
+          "sendEnd": 60.254,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 372.114
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "sni.cloudflaressl.com",
+          "sanList": ["csb.app", "*.csb.app", "sni.cloudflaressl.com"],
+          "issuer": "Cloudflare Inc ECC CA-3",
+          "validFrom": 1592092800,
+          "validTo": 1623672000,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2021' log",
+              "logId":
+                "F65C942FD1773022145418083094568EE34D131933BFDF0C2F200BCC4EF164E3",
+              "timestamp": 1592144349432,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3045022100FA501C68EFDDF67D9EB87B386A1620A11B1C871C7D7ADB54BA7C0CCC2448579102207311518D0EDD72404E7E2D9AC92AB7104279095A62254CF54B066AECB27B6092"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2021 Log",
+              "logId":
+                "5CDC4392FEE6AB4544B15E9AD456E61037FBD5FA47DCA17394B25EE6F6C70ECA",
+              "timestamp": 1592144349477,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30450220397916D2C22156CB1221120F49E296BDB88CF62644982BAEF75DF7FA185E19FB022100955E06938E6FD50DE0EB9506D2AE95010331350672DF8161ABD2D7C061DA9BB7"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "1C067E53675C2B37E7516A1C223663C1"
+    }
+  },
+  {
+    "method": "Page.frameStartedLoading",
+    "params": { "frameId": "1C067E53675C2B37E7516A1C223663C1" }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "name": "init",
+      "timestamp": 105305.280594
+    }
+  },
+  {
+    "method": "Page.frameNavigated",
+    "params": {
+      "frame": {
+        "id": "1C067E53675C2B37E7516A1C223663C1",
+        "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+        "url": "https://1j7om.csb.app/",
+        "securityOrigin": "https://1j7om.csb.app",
+        "mimeType": "text/html"
+      }
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "timestamp": 105305.288495,
+      "dataLength": 229,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "timestamp": 105305.273529,
+      "encodedDataLength": 657,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Page.frameAttached",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "parentFrameId": "1C067E53675C2B37E7516A1C223663C1"
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "loaderId": "784B95F5DE8C4723138CA72939371301",
+      "name": "init",
+      "timestamp": 105305.290275
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "loaderId": "784B95F5DE8C4723138CA72939371301",
+      "name": "DOMContentLoaded",
+      "timestamp": 105305.290646
+    }
+  },
+  {
+    "method": "Page.frameStartedLoading",
+    "params": { "frameId": "E6A6DA1FA18E836F76E84A377F1AB598" }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "documentURL": "https://ow5u1.sse.codesandbox.io/",
+      "request": {
+        "url": "https://ow5u1.sse.codesandbox.io/",
+        "method": "GET",
+        "headers": {
+          "Upgrade-Insecure-Requests": "1",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+          "Referer": "https://1j7om.csb.app/"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 105305.291334,
+      "wallTime": 1595998349.723936,
+      "initiator": {
+        "type": "parser",
+        "url": "https://1j7om.csb.app/",
+        "lineNumber": 3
+      },
+      "type": "Document",
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Page.domContentEventFired",
+    "params": { "timestamp": 105305.291562 }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "name": "DOMContentLoaded",
+      "timestamp": 105305.291562
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "associatedCookies": [],
+      "headers": {
+        ":method": "GET",
+        ":authority": "ow5u1.sse.codesandbox.io",
+        ":scheme": "https",
+        ":path": "/",
+        "upgrade-insecure-requests": "1",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept":
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+        "sec-fetch-site": "cross-site",
+        "sec-fetch-mode": "navigate",
+        "sec-fetch-dest": "iframe",
+        "referer": "https://1j7om.csb.app/",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "name": "firstPaint",
+      "timestamp": 105305.382575
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "name": "firstMeaningfulPaintCandidate",
+      "timestamp": 105305.382575
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "blockedCookies": [
+        {
+          "blockedReasons": ["SameSiteLax"],
+          "cookieLine":
+            "__cfduid=d4ce688e8643102b51bf01817fcbfaf431595998349; expires=Fri, 28-Aug-20 04:52:29 GMT; path=/; domain=.codesandbox.io; HttpOnly; SameSite=Lax; Secure",
+          "cookie": {
+            "name": "__cfduid",
+            "value": "d4ce688e8643102b51bf01817fcbfaf431595998349",
+            "domain": ".codesandbox.io",
+            "path": "/",
+            "expires": 1598590349.143488,
+            "size": 51,
+            "httpOnly": true,
+            "secure": true,
+            "session": false,
+            "sameSite": "Lax",
+            "priority": "Medium"
+          }
+        }
+      ],
+      "headers": {
+        "status": "200",
+        "date": "Wed, 29 Jul 2020 04:52:30 GMT",
+        "content-type": "text/html; charset=utf-8",
+        "set-cookie":
+          "__cfduid=d4ce688e8643102b51bf01817fcbfaf431595998349; expires=Fri, 28-Aug-20 04:52:29 GMT; path=/; domain=.codesandbox.io; HttpOnly; SameSite=Lax; Secure\nsuper-secret-cookie=s%3ATT7YGEXKQ8hkEellp3AUHeSb482YvaSH.rQPMavuljaLqPH%2BpI5bY5agiTdhbpYzEhSj9vGVawok; Path=/; Expires=Wed, 29 Jul 2020 04:53:30 GMT; HttpOnly",
+        "cf-ray": "5ba43b169e1eda52-SYD",
+        "strict-transport-security": "max-age=15724800; includeSubDomains",
+        "vary": "Accept-Encoding",
+        "cf-cache-status": "DYNAMIC",
+        "cf-request-id": "043a83421c0000da528939e200000001",
+        "expect-ct":
+          "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+        "x-powered-by": "Express",
+        "server": "cloudflare",
+        "content-encoding": "br",
+        "alt-svc":
+          "h3-27=\":443\"; ma=86400, h3-28=\":443\"; ma=86400, h3-29=\":443\"; ma=86400"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "timestamp": 105305.712927,
+      "type": "Document",
+      "response": {
+        "url": "https://ow5u1.sse.codesandbox.io/",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "status": "200",
+          "date": "Wed, 29 Jul 2020 04:52:30 GMT",
+          "content-type": "text/html; charset=utf-8",
+          "set-cookie":
+            "__cfduid=d4ce688e8643102b51bf01817fcbfaf431595998349; expires=Fri, 28-Aug-20 04:52:29 GMT; path=/; domain=.codesandbox.io; HttpOnly; SameSite=Lax; Secure\nsuper-secret-cookie=s%3ATT7YGEXKQ8hkEellp3AUHeSb482YvaSH.rQPMavuljaLqPH%2BpI5bY5agiTdhbpYzEhSj9vGVawok; Path=/; Expires=Wed, 29 Jul 2020 04:53:30 GMT; HttpOnly",
+          "cf-ray": "5ba43b169e1eda52-SYD",
+          "strict-transport-security": "max-age=15724800; includeSubDomains",
+          "vary": "Accept-Encoding",
+          "cf-cache-status": "DYNAMIC",
+          "cf-request-id": "043a83421c0000da528939e200000001",
+          "expect-ct":
+            "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+          "x-powered-by": "Express",
+          "server": "cloudflare",
+          "content-encoding": "br",
+          "alt-svc":
+            "h3-27=\":443\"; ma=86400, h3-28=\":443\"; ma=86400, h3-29=\":443\"; ma=86400"
+        },
+        "mimeType": "text/html",
+        "requestHeaders": {
+          ":method": "GET",
+          ":authority": "ow5u1.sse.codesandbox.io",
+          ":scheme": "https",
+          ":path": "/",
+          "upgrade-insecure-requests": "1",
+          "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+          "accept":
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+          "sec-fetch-site": "cross-site",
+          "sec-fetch-mode": "navigate",
+          "sec-fetch-dest": "iframe",
+          "referer": "https://1j7om.csb.app/",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+        },
+        "connectionReused": false,
+        "connectionId": 42,
+        "remoteIPAddress": "104.18.23.207",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 583,
+        "timing": {
+          "requestTime": 105305.292368,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.236,
+          "dnsEnd": 15.649,
+          "connectStart": 15.649,
+          "connectEnd": 51.833,
+          "sslStart": 26.907,
+          "sslEnd": 51.828,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 51.99,
+          "sendEnd": 52.082,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 418.578
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "codesandbox.io",
+          "sanList": [
+            "*.codesandbox.io",
+            "*.sse.codesandbox.io",
+            "sse.codesandbox.io",
+            "codesandbox.io"
+          ],
+          "issuer": "Cloudflare Inc ECC CA-3",
+          "validFrom": 1592524800,
+          "validTo": 1624104000,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2021' log",
+              "logId":
+                "F65C942FD1773022145418083094568EE34D131933BFDF0C2F200BCC4EF164E3",
+              "timestamp": 1592553700283,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "304402202772E2338894114508BF0E3F43848CB631E961FD53A41C8DCB884C2F7414F87302204F38406BD87367B2CED0EAD186C8F98F86AFB489D332E0447A50E962DB567FAD"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2021 Log",
+              "logId":
+                "5CDC4392FEE6AB4544B15E9AD456E61037FBD5FA47DCA17394B25EE6F6C70ECA",
+              "timestamp": 1592553700317,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "304502203959D63B5D969EAC4884F4A1BCF25963597DFD714B73C410C7C90A50AF570DBD022100EB7FEE5091C046E5F1AFD308CDD78BE6C5C4F9FBB07ABF3A98886858D636C27C"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598"
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "name": "init",
+      "timestamp": 105305.7144
+    }
+  },
+  {
+    "method": "Page.frameNavigated",
+    "params": {
+      "frame": {
+        "id": "E6A6DA1FA18E836F76E84A377F1AB598",
+        "parentId": "1C067E53675C2B37E7516A1C223663C1",
+        "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+        "name": "",
+        "url": "https://ow5u1.sse.codesandbox.io/",
+        "securityOrigin": "https://ow5u1.sse.codesandbox.io",
+        "mimeType": "text/html"
+      }
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "timestamp": 105305.717852,
+      "dataLength": 363,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "timestamp": 105305.711621,
+      "encodedDataLength": 792,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "45305.3",
+      "associatedCookies": [
+        {
+          "blockedReasons": [],
+          "cookie": {
+            "name": "super-secret-cookie",
+            "value":
+              "s%3ATT7YGEXKQ8hkEellp3AUHeSb482YvaSH.rQPMavuljaLqPH%2BpI5bY5agiTdhbpYzEhSj9vGVawok",
+            "domain": "ow5u1.sse.codesandbox.io",
+            "path": "/",
+            "expires": 1595998410.143544,
+            "size": 101,
+            "httpOnly": true,
+            "secure": false,
+            "session": false,
+            "priority": "Medium"
+          }
+        }
+      ],
+      "headers": {
+        ":method": "GET",
+        ":authority": "ow5u1.sse.codesandbox.io",
+        ":scheme": "https",
+        ":path": "/style.css",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept": "text/css,*/*;q=0.1",
+        "sec-fetch-site": "same-origin",
+        "sec-fetch-mode": "no-cors",
+        "sec-fetch-dest": "style",
+        "referer": "https://ow5u1.sse.codesandbox.io/",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
+        "cookie":
+          "super-secret-cookie=s%3ATT7YGEXKQ8hkEellp3AUHeSb482YvaSH.rQPMavuljaLqPH%2BpI5bY5agiTdhbpYzEhSj9vGVawok"
+      }
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "45305.3",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "documentURL": "https://ow5u1.sse.codesandbox.io/",
+      "request": {
+        "url": "https://ow5u1.sse.codesandbox.io/style.css",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://ow5u1.sse.codesandbox.io/",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 105305.718827,
+      "wallTime": 1595998350.151346,
+      "initiator": {
+        "type": "parser",
+        "url": "https://ow5u1.sse.codesandbox.io/",
+        "lineNumber": 5
+      },
+      "type": "Stylesheet",
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "45305.4",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "documentURL": "https://ow5u1.sse.codesandbox.io/",
+      "request": {
+        "url": "https://sse-0.codesandbox.io/client-hook-3.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://ow5u1.sse.codesandbox.io/",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 105305.719236,
+      "wallTime": 1595998350.151754,
+      "initiator": {
+        "type": "parser",
+        "url": "https://ow5u1.sse.codesandbox.io/",
+        "lineNumber": 6
+      },
+      "type": "Script",
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "45305.3",
+      "blockedCookies": [
+        {
+          "blockedReasons": ["SameSiteLax"],
+          "cookieLine":
+            "__cfduid=d1a3eeb06208778c719235145dfee08521595998350; expires=Fri, 28-Aug-20 04:52:30 GMT; path=/; domain=.codesandbox.io; HttpOnly; SameSite=Lax; Secure",
+          "cookie": {
+            "name": "__cfduid",
+            "value": "d1a3eeb06208778c719235145dfee08521595998350",
+            "domain": ".codesandbox.io",
+            "path": "/",
+            "expires": 1598590350.519569,
+            "size": 51,
+            "httpOnly": true,
+            "secure": true,
+            "session": false,
+            "sameSite": "Lax",
+            "priority": "Medium"
+          }
+        }
+      ],
+      "headers": {
+        "status": "200",
+        "date": "Wed, 29 Jul 2020 04:52:30 GMT",
+        "content-type": "text/css; charset=UTF-8",
+        "set-cookie":
+          "__cfduid=d1a3eeb06208778c719235145dfee08521595998350; expires=Fri, 28-Aug-20 04:52:30 GMT; path=/; domain=.codesandbox.io; HttpOnly; SameSite=Lax; Secure",
+        "cf-ray": "5ba43b18e992da52-SYD",
+        "cache-control": "public, max-age=0",
+        "etag": "W/\"732-17398e8d619\"",
+        "last-modified": "Wed, 29 Jul 2020 04:51:02 GMT",
+        "strict-transport-security": "max-age=15724800; includeSubDomains",
+        "vary": "Accept-Encoding",
+        "cf-cache-status": "DYNAMIC",
+        "cf-request-id": "043a8343940000da52893ab200000001",
+        "expect-ct":
+          "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+        "x-powered-by": "Express",
+        "server": "cloudflare",
+        "content-encoding": "br",
+        "alt-svc":
+          "h3-27=\":443\"; ma=86400, h3-28=\":443\"; ma=86400, h3-29=\":443\"; ma=86400"
+      }
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "name": "networkAlmostIdle",
+      "timestamp": 105305.291642
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "name": "networkIdle",
+      "timestamp": 105305.291642
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "45305.3",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "timestamp": 105306.088488,
+      "type": "Stylesheet",
+      "response": {
+        "url": "https://ow5u1.sse.codesandbox.io/style.css",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Wed, 29 Jul 2020 04:52:30 GMT",
+          "content-encoding": "br",
+          "vary": "Accept-Encoding",
+          "cf-cache-status": "DYNAMIC",
+          "x-powered-by": "Express",
+          "status": "200",
+          "alt-svc":
+            "h3-27=\":443\"; ma=86400, h3-28=\":443\"; ma=86400, h3-29=\":443\"; ma=86400",
+          "cf-request-id": "043a8343940000da52893ab200000001",
+          "last-modified": "Wed, 29 Jul 2020 04:51:02 GMT",
+          "server": "cloudflare",
+          "etag": "W/\"732-17398e8d619\"",
+          "expect-ct":
+            "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+          "strict-transport-security": "max-age=15724800; includeSubDomains",
+          "content-type": "text/css; charset=UTF-8",
+          "cache-control": "public, max-age=0",
+          "cf-ray": "5ba43b18e992da52-SYD"
+        },
+        "mimeType": "text/css",
+        "connectionReused": true,
+        "connectionId": 42,
+        "remoteIPAddress": "104.18.23.207",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 251,
+        "timing": {
+          "requestTime": 105305.719385,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 0.232,
+          "sendEnd": 1.146,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 367.665
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "codesandbox.io",
+          "sanList": [
+            "*.codesandbox.io",
+            "*.sse.codesandbox.io",
+            "sse.codesandbox.io",
+            "codesandbox.io"
+          ],
+          "issuer": "Cloudflare Inc ECC CA-3",
+          "validFrom": 1592524800,
+          "validTo": 1624104000,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2021' log",
+              "logId":
+                "F65C942FD1773022145418083094568EE34D131933BFDF0C2F200BCC4EF164E3",
+              "timestamp": 1592553700283,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "304402202772E2338894114508BF0E3F43848CB631E961FD53A41C8DCB884C2F7414F87302204F38406BD87367B2CED0EAD186C8F98F86AFB489D332E0447A50E962DB567FAD"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2021 Log",
+              "logId":
+                "5CDC4392FEE6AB4544B15E9AD456E61037FBD5FA47DCA17394B25EE6F6C70ECA",
+              "timestamp": 1592553700317,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "304502203959D63B5D969EAC4884F4A1BCF25963597DFD714B73C410C7C90A50AF570DBD022100EB7FEE5091C046E5F1AFD308CDD78BE6C5C4F9FBB07ABF3A98886858D636C27C"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "45305.3",
+      "timestamp": 105306.088587,
+      "dataLength": 1842,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "45305.3",
+      "timestamp": 105306.088911,
+      "dataLength": 0,
+      "encodedDataLength": 631
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "45305.3",
+      "timestamp": 105306.087445,
+      "encodedDataLength": 882,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "45305.4",
+      "associatedCookies": [
+        {
+          "blockedReasons": ["DomainMismatch"],
+          "cookie": {
+            "name": "super-secret-cookie",
+            "value":
+              "s%3ATT7YGEXKQ8hkEellp3AUHeSb482YvaSH.rQPMavuljaLqPH%2BpI5bY5agiTdhbpYzEhSj9vGVawok",
+            "domain": "ow5u1.sse.codesandbox.io",
+            "path": "/",
+            "expires": 1595998410.143544,
+            "size": 101,
+            "httpOnly": true,
+            "secure": false,
+            "session": false,
+            "priority": "Medium"
+          }
+        }
+      ],
+      "headers": {
+        ":method": "GET",
+        ":authority": "sse-0.codesandbox.io",
+        ":scheme": "https",
+        ":path": "/client-hook-3.js",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept": "*/*",
+        "sec-fetch-site": "same-site",
+        "sec-fetch-mode": "no-cors",
+        "sec-fetch-dest": "script",
+        "referer": "https://ow5u1.sse.codesandbox.io/",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "45305.4",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "server": "nginx/1.17.10",
+        "date": "Wed, 29 Jul 2020 04:52:31 GMT",
+        "content-type": "application/javascript; charset=utf-8",
+        "vary": "Accept-Encoding",
+        "cache-control": "max-age=0",
+        "last-modified": "Mon, 20 Jul 2020 15:47:27 GMT",
+        "strict-transport-security": "max-age=15724800; includeSubDomains",
+        "content-encoding": "gzip"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "45305.4",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "timestamp": 105306.674952,
+      "type": "Script",
+      "response": {
+        "url": "https://sse-0.codesandbox.io/client-hook-3.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Wed, 29 Jul 2020 04:52:31 GMT",
+          "content-encoding": "gzip",
+          "last-modified": "Mon, 20 Jul 2020 15:47:27 GMT",
+          "server": "nginx/1.17.10",
+          "vary": "Accept-Encoding",
+          "content-type": "application/javascript; charset=utf-8",
+          "status": "200",
+          "cache-control": "max-age=0",
+          "strict-transport-security": "max-age=15724800; includeSubDomains"
+        },
+        "mimeType": "application/javascript",
+        "connectionReused": false,
+        "connectionId": 57,
+        "remoteIPAddress": "5.9.114.19",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 204,
+        "timing": {
+          "requestTime": 105305.719941,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.339,
+          "dnsEnd": 16.436,
+          "connectStart": 16.436,
+          "connectEnd": 635.747,
+          "sslStart": 316.56,
+          "sslEnd": 635.742,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 635.843,
+          "sendEnd": 635.926,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 950.745
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "sse-0.codesandbox.io",
+          "sanList": ["*.sse-0.codesandbox.io", "sse-0.codesandbox.io"],
+          "issuer": "Let's Encrypt Authority X3",
+          "validFrom": 1595139821,
+          "validTo": 1602915821,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Cloudflare 'Nimbus2020' Log",
+              "logId":
+                "5EA773F9DF56C0E7B536487DD049E0327A919A0C84A112128418759681714558",
+              "timestamp": 1595143421677,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3046022100D9147E347D5C125BA03FC3F91BC373987B361CDCA61FD1CC7367C6E0EAE80778022100E9F8348E4CABA35C02F5FD2A5E7444ECDB4792B35FDC817AB1DDCFAB4ED07B17"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2020' log",
+              "logId":
+                "B21E05CC8BA2CD8A204E8766F92BB98A2520676BDAFA70E7B249532DEF8B905E",
+              "timestamp": 1595143421668,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "304402207C5C95F30796CE98B80911B66FA75FDBF6F6ED3785728200AE40C441F78D5BDE0220278B9945F074C28E1FD1E72F862B2C5EF6602E730AB3E903DFC6D1BE74CC5AA8"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "45305.4",
+      "timestamp": 105306.675066,
+      "dataLength": 16384,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "45305.4",
+      "timestamp": 105306.675503,
+      "dataLength": 2871,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "45305.4",
+      "timestamp": 105306.675828,
+      "dataLength": 0,
+      "encodedDataLength": 6079
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "45305.4",
+      "timestamp": 105306.675498,
+      "encodedDataLength": 6283,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "name": "load",
+      "timestamp": 105306.679513
+    }
+  },
+  {
+    "method": "Page.frameStoppedLoading",
+    "params": { "frameId": "E6A6DA1FA18E836F76E84A377F1AB598" }
+  },
+  { "method": "Page.loadEventFired", "params": { "timestamp": 105306.685884 } },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "name": "load",
+      "timestamp": 105306.685884
+    }
+  },
+  {
+    "method": "Page.frameStoppedLoading",
+    "params": { "frameId": "1C067E53675C2B37E7516A1C223663C1" }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "name": "DOMContentLoaded",
+      "timestamp": 105306.686053
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "45305.7",
+      "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "documentURL": "https://1j7om.csb.app/",
+      "request": {
+        "url": "https://1j7om.csb.app/favicon.ico",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://1j7om.csb.app/",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 105306.688537,
+      "wallTime": 1595998351.121031,
+      "initiator": { "type": "other" },
+      "type": "Other",
+      "frameId": "1C067E53675C2B37E7516A1C223663C1",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "45305.7",
+      "associatedCookies": [
+        {
+          "blockedReasons": [],
+          "cookie": {
+            "name": "__cfduid",
+            "value": "da0f64c008e4700b2ef1278a954bbfaab1595998349",
+            "domain": ".csb.app",
+            "path": "/",
+            "expires": 1598590349.705596,
+            "size": 51,
+            "httpOnly": true,
+            "secure": false,
+            "session": false,
+            "sameSite": "Lax",
+            "priority": "Medium"
+          }
+        }
+      ],
+      "headers": {
+        ":method": "GET",
+        ":authority": "1j7om.csb.app",
+        ":scheme": "https",
+        ":path": "/favicon.ico",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept": "image/webp,image/apng,image/*,*/*;q=0.8",
+        "sec-fetch-site": "same-origin",
+        "sec-fetch-mode": "no-cors",
+        "sec-fetch-dest": "image",
+        "referer": "https://1j7om.csb.app/",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
+        "cookie": "__cfduid=da0f64c008e4700b2ef1278a954bbfaab1595998349"
+      }
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "name": "firstPaint",
+      "timestamp": 105306.717356
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "name": "firstContentfulPaint",
+      "timestamp": 105306.717356
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "name": "firstMeaningfulPaintCandidate",
+      "timestamp": 105306.717356
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "45305.7",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "date": "Wed, 29 Jul 2020 04:52:31 GMT",
+        "content-type": "image/x-icon",
+        "last-modified": "Mon, 27 Jul 2020 12:13:58 GMT",
+        "etag": "W/\"5f1ec506-3aee\"",
+        "via": "1.1 google",
+        "alt-svc":
+          "h3-27=\":443\"; ma=86400, h3-28=\":443\"; ma=86400, h3-29=\":443\"; ma=86400",
+        "cf-cache-status": "REVALIDATED",
+        "expires": "Wed, 29 Jul 2020 08:52:31 GMT",
+        "cache-control": "public, max-age=14400",
+        "cf-request-id": "043a83475c000016c931346200000001",
+        "expect-ct":
+          "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+        "vary": "Accept-Encoding",
+        "server": "cloudflare",
+        "cf-ray": "5ba43b1efb9d16c9-SYD",
+        "content-encoding": "br"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "45305.7",
+      "loaderId": "ACA837EB5A4D87CCB6D338922843C11D",
+      "timestamp": 105307.04912,
+      "type": "Other",
+      "response": {
+        "url": "https://1j7om.csb.app/favicon.ico",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Wed, 29 Jul 2020 04:52:31 GMT",
+          "via": "1.1 google",
+          "cf-cache-status": "REVALIDATED",
+          "status": "200",
+          "content-encoding": "br",
+          "alt-svc":
+            "h3-27=\":443\"; ma=86400, h3-28=\":443\"; ma=86400, h3-29=\":443\"; ma=86400",
+          "cf-request-id": "043a83475c000016c931346200000001",
+          "last-modified": "Mon, 27 Jul 2020 12:13:58 GMT",
+          "server": "cloudflare",
+          "etag": "W/\"5f1ec506-3aee\"",
+          "expect-ct":
+            "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+          "vary": "Accept-Encoding",
+          "content-type": "image/x-icon",
+          "cache-control": "public, max-age=14400",
+          "cf-ray": "5ba43b1efb9d16c9-SYD",
+          "expires": "Wed, 29 Jul 2020 08:52:31 GMT"
+        },
+        "mimeType": "image/x-icon",
+        "connectionReused": true,
+        "connectionId": 27,
+        "remoteIPAddress": "104.18.26.114",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 188,
+        "timing": {
+          "requestTime": 105306.688854,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 0.211,
+          "sendEnd": 0.337,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 359.058
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "sni.cloudflaressl.com",
+          "sanList": ["csb.app", "*.csb.app", "sni.cloudflaressl.com"],
+          "issuer": "Cloudflare Inc ECC CA-3",
+          "validFrom": 1592092800,
+          "validTo": 1623672000,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2021' log",
+              "logId":
+                "F65C942FD1773022145418083094568EE34D131933BFDF0C2F200BCC4EF164E3",
+              "timestamp": 1592144349432,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3045022100FA501C68EFDDF67D9EB87B386A1620A11B1C871C7D7ADB54BA7C0CCC2448579102207311518D0EDD72404E7E2D9AC92AB7104279095A62254CF54B066AECB27B6092"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2021 Log",
+              "logId":
+                "5CDC4392FEE6AB4544B15E9AD456E61037FBD5FA47DCA17394B25EE6F6C70ECA",
+              "timestamp": 1592144349477,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30450220397916D2C22156CB1221120F49E296BDB88CF62644982BAEF75DF7FA185E19FB022100955E06938E6FD50DE0EB9506D2AE95010331350672DF8161ABD2D7C061DA9BB7"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "1C067E53675C2B37E7516A1C223663C1"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "45305.7",
+      "timestamp": 105307.049217,
+      "dataLength": 15086,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "45305.7",
+      "timestamp": 105307.049637,
+      "dataLength": 0,
+      "encodedDataLength": 2012
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "45305.7",
+      "timestamp": 105307.048389,
+      "encodedDataLength": 2200,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "name": "networkAlmostIdle",
+      "timestamp": 105306.686071
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "name": "firstMeaningfulPaint",
+      "timestamp": 105306.717356
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "E6A6DA1FA18E836F76E84A377F1AB598",
+      "loaderId": "05E77E26D8F1FEFE1F13AF8F38E34DD1",
+      "name": "networkIdle",
+      "timestamp": 105306.686071
+    }
+  }
+]

--- a/test/perflogs/samesite-sandbox.glitch.me.json
+++ b/test/perflogs/samesite-sandbox.glitch.me.json
@@ -1,0 +1,1304 @@
+[
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "E1917A4F73995EFBE1511FFB294BF42C",
+      "name": "commit",
+      "timestamp": 101502.464606
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "E1917A4F73995EFBE1511FFB294BF42C",
+      "name": "DOMContentLoaded",
+      "timestamp": 101502.464778
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "E1917A4F73995EFBE1511FFB294BF42C",
+      "name": "load",
+      "timestamp": 101502.465212
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "E1917A4F73995EFBE1511FFB294BF42C",
+      "name": "networkAlmostIdle",
+      "timestamp": 101502.466024
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "E1917A4F73995EFBE1511FFB294BF42C",
+      "name": "networkIdle",
+      "timestamp": 101502.466024
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "documentURL": "https://samesite-sandbox.glitch.me/",
+      "request": {
+        "url": "https://samesite-sandbox.glitch.me/",
+        "method": "GET",
+        "headers": {
+          "Upgrade-Insecure-Requests": "1",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 101502.530226,
+      "wallTime": 1595994540.608392,
+      "initiator": { "type": "other" },
+      "type": "Document",
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "associatedCookies": [],
+      "headers": {
+        ":method": "GET",
+        ":authority": "samesite-sandbox.glitch.me",
+        ":scheme": "https",
+        ":path": "/",
+        "upgrade-insecure-requests": "1",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept":
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+        "sec-fetch-site": "none",
+        "sec-fetch-mode": "navigate",
+        "sec-fetch-user": "?1",
+        "sec-fetch-dest": "document",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "E1917A4F73995EFBE1511FFB294BF42C",
+      "name": "networkAlmostIdle",
+      "timestamp": 101502.466024
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "E1917A4F73995EFBE1511FFB294BF42C",
+      "name": "networkIdle",
+      "timestamp": 101502.466024
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "date": "Wed, 29 Jul 2020 03:49:01 GMT",
+        "content-type": "text/html; charset=UTF-8",
+        "content-length": "10494",
+        "x-powered-by": "Express",
+        "strict-transport-security":
+          "max-age=63072000; inlcudeSubdomains; preload",
+        "referrer-policy": "strict-origin-when-cross-origin",
+        "set-cookie":
+          "ck03=vl03; SameSite=InvalidValue\nck00=vl00; Path=/\nck01=vl01; Path=/; Secure; SameSite=None\nck02=vl02; Path=/; SameSite=None\nck04=vl04; Path=/; SameSite=Lax\nck05=vl05; Path=/; SameSite=Strict",
+        "accept-ranges": "bytes",
+        "cache-control": "public, max-age=0",
+        "last-modified": "Thu, 26 Mar 2020 12:31:57 GMT",
+        "etag": "W/\"28fe-17116d3e248\""
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "timestamp": 101503.419814,
+      "type": "Document",
+      "response": {
+        "url": "https://samesite-sandbox.glitch.me/",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "status": "200",
+          "date": "Wed, 29 Jul 2020 03:49:01 GMT",
+          "content-type": "text/html; charset=UTF-8",
+          "content-length": "10494",
+          "x-powered-by": "Express",
+          "strict-transport-security":
+            "max-age=63072000; inlcudeSubdomains; preload",
+          "referrer-policy": "strict-origin-when-cross-origin",
+          "set-cookie":
+            "ck03=vl03; SameSite=InvalidValue\nck00=vl00; Path=/\nck01=vl01; Path=/; Secure; SameSite=None\nck02=vl02; Path=/; SameSite=None\nck04=vl04; Path=/; SameSite=Lax\nck05=vl05; Path=/; SameSite=Strict",
+          "accept-ranges": "bytes",
+          "cache-control": "public, max-age=0",
+          "last-modified": "Thu, 26 Mar 2020 12:31:57 GMT",
+          "etag": "W/\"28fe-17116d3e248\""
+        },
+        "mimeType": "text/html",
+        "requestHeaders": {
+          ":method": "GET",
+          ":authority": "samesite-sandbox.glitch.me",
+          ":scheme": "https",
+          ":path": "/",
+          "upgrade-insecure-requests": "1",
+          "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+          "accept":
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+          "sec-fetch-site": "none",
+          "sec-fetch-mode": "navigate",
+          "sec-fetch-user": "?1",
+          "sec-fetch-dest": "document",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+        },
+        "connectionReused": false,
+        "connectionId": 27,
+        "remoteIPAddress": "54.164.246.13",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 464,
+        "timing": {
+          "requestTime": 101502.530878,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.219,
+          "dnsEnd": 16.358,
+          "connectStart": 16.358,
+          "connectEnd": 453.89,
+          "sslStart": 229.023,
+          "sslEnd": 453.884,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 454.664,
+          "sendEnd": 454.751,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 887.04
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "glitch.com",
+          "sanList": [
+            "glitch.com",
+            "glitch.me",
+            "gomix.com",
+            "*.glitch.com",
+            "gomix.me",
+            "*.gomix.me",
+            "*.glitch.me",
+            "hyperdev.com",
+            "*.hyperdev.com",
+            "*.gomix.com"
+          ],
+          "issuer": "Amazon",
+          "validFrom": 1581984000,
+          "validTo": 1616068800,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Skydiver' log",
+              "logId":
+                "BBD9DFBC1F8A71B593942397AA927B473857950AAB52E81A909664368E1ED185",
+              "timestamp": 1582065086753,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30460221008F85EB81321626E05DFC2D21CD76F747F633F1BB2DDD08EC1B9247F09705CADD022100C40B8B3618B01225F8F1B091FC699C7986178429FF95A475066CF4567575B2CA"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Log Server 2",
+              "logId":
+                "8775BFE7597CF88C43995FBDF36EFF568D475636FF4AB560C1B4EAFF5EA0830F",
+              "timestamp": 1582065086835,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30450221009BD96A9E4B69EAB9CD766C423B14902F48BA85026C8055DFD4166528DDC6C22C02205B4520A3AF7654586FC7718787A8081A3C939D757DEB0FDD32AAE80300B7ABB5"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "447C526AAC595F429B694068BE35F750"
+    }
+  },
+  {
+    "method": "Page.frameStartedLoading",
+    "params": { "frameId": "447C526AAC595F429B694068BE35F750" }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "name": "init",
+      "timestamp": 101503.42367
+    }
+  },
+  {
+    "method": "Page.frameNavigated",
+    "params": {
+      "frame": {
+        "id": "447C526AAC595F429B694068BE35F750",
+        "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+        "url": "https://samesite-sandbox.glitch.me/",
+        "securityOrigin": "https://samesite-sandbox.glitch.me",
+        "mimeType": "text/html"
+      }
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "timestamp": 101503.431291,
+      "dataLength": 10494,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "timestamp": 101503.418486,
+      "encodedDataLength": 10985,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Page.frameAttached",
+    "params": {
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "parentFrameId": "447C526AAC595F429B694068BE35F750",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "",
+            "scriptId": "13",
+            "url": "https://samesite-sandbox.glitch.me/",
+            "lineNumber": 372,
+            "columnNumber": 18
+          }
+        ]
+      }
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "loaderId": "EBF6C7225F44E8D5DE95283F7A2A45E8",
+      "name": "init",
+      "timestamp": 101503.563853
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "loaderId": "EBF6C7225F44E8D5DE95283F7A2A45E8",
+      "name": "DOMContentLoaded",
+      "timestamp": 101503.565014
+    }
+  },
+  {
+    "method": "Page.frameStartedLoading",
+    "params": { "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4" }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "loaderId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "documentURL":
+        "https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html",
+      "request": {
+        "url":
+          "https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html",
+        "method": "GET",
+        "headers": {
+          "Upgrade-Insecure-Requests": "1",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+          "Referer": "https://samesite-sandbox.glitch.me/"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "strict-origin-when-cross-origin"
+      },
+      "timestamp": 101503.566432,
+      "wallTime": 1595994541.644641,
+      "initiator": {
+        "type": "script",
+        "stack": {
+          "callFrames": [
+            {
+              "functionName": "",
+              "scriptId": "13",
+              "url": "https://samesite-sandbox.glitch.me/",
+              "lineNumber": 372,
+              "columnNumber": 18
+            }
+          ]
+        }
+      },
+      "type": "Document",
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Page.domContentEventFired",
+    "params": { "timestamp": 101503.566471 }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "name": "DOMContentLoaded",
+      "timestamp": 101503.566471
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "name": "firstPaint",
+      "timestamp": 101503.59997
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "name": "firstContentfulPaint",
+      "timestamp": 101503.59997
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "name": "firstMeaningfulPaintCandidate",
+      "timestamp": 101503.59997
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "associatedCookies": [],
+      "headers": {
+        ":method": "GET",
+        ":authority": "googlechromelabs.github.io",
+        ":scheme": "https",
+        ":path": "/samesite-examples/crosssite-embed.html",
+        "upgrade-insecure-requests": "1",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept":
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+        "sec-fetch-site": "cross-site",
+        "sec-fetch-mode": "navigate",
+        "sec-fetch-dest": "iframe",
+        "referer": "https://samesite-sandbox.glitch.me/",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "loaderId": "EBF6C7225F44E8D5DE95283F7A2A45E8",
+      "name": "networkAlmostIdle",
+      "timestamp": 101503.565101
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "loaderId": "EBF6C7225F44E8D5DE95283F7A2A45E8",
+      "name": "networkIdle",
+      "timestamp": 101503.565101
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "name": "networkAlmostIdle",
+      "timestamp": 101503.566552
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "name": "firstMeaningfulPaint",
+      "timestamp": 101503.59997
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "name": "networkIdle",
+      "timestamp": 101503.566552
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "content-type": "text/html; charset=utf-8",
+        "server": "GitHub.com",
+        "strict-transport-security": "max-age=31556952",
+        "last-modified": "Thu, 02 Apr 2020 11:29:48 GMT",
+        "etag": "W/\"5e85ccac-2b9\"",
+        "access-control-allow-origin": "*",
+        "expires": "Wed, 29 Jul 2020 03:48:56 GMT",
+        "cache-control": "max-age=600",
+        "content-encoding": "gzip",
+        "x-proxy-cache": "MISS",
+        "x-github-request-id": "16B8:5823:26B58:32FB9:5F20EF50",
+        "accept-ranges": "bytes",
+        "date": "Wed, 29 Jul 2020 03:49:02 GMT",
+        "via": "1.1 varnish",
+        "age": "0",
+        "x-served-by": "cache-syd10121-SYD",
+        "x-cache": "HIT",
+        "x-cache-hits": "1",
+        "x-timer": "S1595994542.820717,VS0,VE804",
+        "vary": "Accept-Encoding",
+        "x-fastly-request-id": "2a80e9628aaf66d0eac077a1eb53e623008b2cae",
+        "content-length": "409"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "loaderId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "timestamp": 101504.443759,
+      "type": "Document",
+      "response": {
+        "url":
+          "https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "status": "200",
+          "content-type": "text/html; charset=utf-8",
+          "server": "GitHub.com",
+          "strict-transport-security": "max-age=31556952",
+          "last-modified": "Thu, 02 Apr 2020 11:29:48 GMT",
+          "etag": "W/\"5e85ccac-2b9\"",
+          "access-control-allow-origin": "*",
+          "expires": "Wed, 29 Jul 2020 03:48:56 GMT",
+          "cache-control": "max-age=600",
+          "content-encoding": "gzip",
+          "x-proxy-cache": "MISS",
+          "x-github-request-id": "16B8:5823:26B58:32FB9:5F20EF50",
+          "accept-ranges": "bytes",
+          "date": "Wed, 29 Jul 2020 03:49:02 GMT",
+          "via": "1.1 varnish",
+          "age": "0",
+          "x-served-by": "cache-syd10121-SYD",
+          "x-cache": "HIT",
+          "x-cache-hits": "1",
+          "x-timer": "S1595994542.820717,VS0,VE804",
+          "vary": "Accept-Encoding",
+          "x-fastly-request-id": "2a80e9628aaf66d0eac077a1eb53e623008b2cae",
+          "content-length": "409"
+        },
+        "mimeType": "text/html",
+        "requestHeaders": {
+          ":method": "GET",
+          ":authority": "googlechromelabs.github.io",
+          ":scheme": "https",
+          ":path": "/samesite-examples/crosssite-embed.html",
+          "upgrade-insecure-requests": "1",
+          "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+          "accept":
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+          "sec-fetch-site": "cross-site",
+          "sec-fetch-mode": "navigate",
+          "sec-fetch-dest": "iframe",
+          "referer": "https://samesite-sandbox.glitch.me/",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+        },
+        "connectionReused": false,
+        "connectionId": 42,
+        "remoteIPAddress": "185.199.108.153",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 378,
+        "timing": {
+          "requestTime": 101503.568005,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.576,
+          "dnsEnd": 26.098,
+          "connectStart": 26.098,
+          "connectEnd": 58.323,
+          "sslStart": 37.65,
+          "sslEnd": 58.317,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 58.553,
+          "sendEnd": 58.649,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 874.356
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "www.github.com",
+          "sanList": [
+            "www.github.com",
+            "*.github.com",
+            "github.com",
+            "*.github.io",
+            "github.io",
+            "*.githubusercontent.com",
+            "githubusercontent.com"
+          ],
+          "issuer": "DigiCert SHA2 High Assurance Server CA",
+          "validFrom": 1588723200,
+          "validTo": 1649937600,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Xenon2022' log",
+              "logId":
+                "46A555EB75FA912030B5A28969F4F37D112C4174BEFD49B885ABF2FC70FE6D47",
+              "timestamp": 1588788666134,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "3045022100E7DCBAC3DA1AA00A0CD9FBC5ABA2A87D8591874C519B854411A30706DB016148022016712618C0ED2196525A39ED8B251BCBBA7251E780336FA13355C351D0B53AF7"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2022 Log",
+              "logId":
+                "2245450759552456963FA12FF1F76D86E0232663ADC04B7F5DC6835C6EE20F02",
+              "timestamp": 1588788666047,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30440220661238A2A136DCD7FFE10889D8217E8EF21A61E682D1546093C6B4C17D2453DB0220673EF1DD93482909163CA38569A5B7031701D03CE116C0FA8318646E5D69D008"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Nessie2022 Log",
+              "logId":
+                "51A3B0F5FD01799C566DB837788F0CA47ACC1B27CBF79E88429A0DFED48B05E5",
+              "timestamp": 1588788666121,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30450220143FE8497E4C20AD5AEA29EC875EACDD3E6F29F9B03ADE4EEF97CF71A263C70B022100ED2F371F1145750850AA98E36D66C854103CF0D9FFAE269FE496FC877A0957C7"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4"
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "loaderId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "name": "init",
+      "timestamp": 101504.445684
+    }
+  },
+  {
+    "method": "Page.frameNavigated",
+    "params": {
+      "frame": {
+        "id": "1CF39B1FEA7835B89AD7BC3742E338C4",
+        "parentId": "447C526AAC595F429B694068BE35F750",
+        "loaderId": "6FD5005E76F02FF80B1A28761D02BA11",
+        "name": "",
+        "url":
+          "https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html",
+        "securityOrigin": "https://googlechromelabs.github.io",
+        "mimeType": "text/html"
+      }
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "timestamp": 101504.449234,
+      "dataLength": 697,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "timestamp": 101504.442635,
+      "encodedDataLength": 796,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "13720.3",
+      "loaderId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "documentURL":
+        "https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html",
+      "request": {
+        "url": "https://samesite-sandbox.glitch.me/cookies.json",
+        "method": "GET",
+        "headers": {
+          "Referer":
+            "https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 101504.450409,
+      "wallTime": 1595994542.528458,
+      "initiator": {
+        "type": "script",
+        "stack": {
+          "callFrames": [
+            {
+              "functionName": "fetchCookies",
+              "scriptId": "17",
+              "url":
+                "https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html",
+              "lineNumber": 16,
+              "columnNumber": 8
+            },
+            {
+              "functionName": "",
+              "scriptId": "17",
+              "url":
+                "https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html",
+              "lineNumber": 19,
+              "columnNumber": 2
+            }
+          ]
+        }
+      },
+      "type": "XHR",
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "13720.3",
+      "associatedCookies": [
+        {
+          "blockedReasons": ["SameSiteLax"],
+          "cookie": {
+            "name": "ck04",
+            "value": "vl04",
+            "domain": "samesite-sandbox.glitch.me",
+            "path": "/",
+            "expires": -1,
+            "size": 8,
+            "httpOnly": false,
+            "secure": false,
+            "session": true,
+            "sameSite": "Lax",
+            "priority": "Medium"
+          }
+        },
+        {
+          "blockedReasons": ["SameSiteStrict"],
+          "cookie": {
+            "name": "ck05",
+            "value": "vl05",
+            "domain": "samesite-sandbox.glitch.me",
+            "path": "/",
+            "expires": -1,
+            "size": 8,
+            "httpOnly": false,
+            "secure": false,
+            "session": true,
+            "sameSite": "Strict",
+            "priority": "Medium"
+          }
+        },
+        {
+          "blockedReasons": [],
+          "cookie": {
+            "name": "ck03",
+            "value": "vl03",
+            "domain": "samesite-sandbox.glitch.me",
+            "path": "/",
+            "expires": -1,
+            "size": 8,
+            "httpOnly": false,
+            "secure": false,
+            "session": true,
+            "priority": "Medium"
+          }
+        },
+        {
+          "blockedReasons": [],
+          "cookie": {
+            "name": "ck00",
+            "value": "vl00",
+            "domain": "samesite-sandbox.glitch.me",
+            "path": "/",
+            "expires": -1,
+            "size": 8,
+            "httpOnly": false,
+            "secure": false,
+            "session": true,
+            "priority": "Medium"
+          }
+        },
+        {
+          "blockedReasons": [],
+          "cookie": {
+            "name": "ck01",
+            "value": "vl01",
+            "domain": "samesite-sandbox.glitch.me",
+            "path": "/",
+            "expires": -1,
+            "size": 8,
+            "httpOnly": false,
+            "secure": true,
+            "session": true,
+            "sameSite": "None",
+            "priority": "Medium"
+          }
+        },
+        {
+          "blockedReasons": [],
+          "cookie": {
+            "name": "ck02",
+            "value": "vl02",
+            "domain": "samesite-sandbox.glitch.me",
+            "path": "/",
+            "expires": -1,
+            "size": 8,
+            "httpOnly": false,
+            "secure": false,
+            "session": true,
+            "sameSite": "None",
+            "priority": "Medium"
+          }
+        }
+      ],
+      "headers": {
+        ":method": "GET",
+        ":authority": "samesite-sandbox.glitch.me",
+        ":scheme": "https",
+        ":path": "/cookies.json",
+        "user-agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept": "*/*",
+        "origin": "https://googlechromelabs.github.io",
+        "sec-fetch-site": "cross-site",
+        "sec-fetch-mode": "cors",
+        "sec-fetch-dest": "empty",
+        "referer":
+          "https://googlechromelabs.github.io/samesite-examples/crosssite-embed.html",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
+        "cookie": "ck03=vl03; ck00=vl00; ck01=vl01; ck02=vl02"
+      }
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "loaderId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "name": "load",
+      "timestamp": 101504.451249
+    }
+  },
+  {
+    "method": "Page.frameStoppedLoading",
+    "params": { "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4" }
+  },
+  { "method": "Page.loadEventFired", "params": { "timestamp": 101504.451833 } },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "name": "load",
+      "timestamp": 101504.451833
+    }
+  },
+  {
+    "method": "Page.frameStoppedLoading",
+    "params": { "frameId": "447C526AAC595F429B694068BE35F750" }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "loaderId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "name": "DOMContentLoaded",
+      "timestamp": 101504.452001
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "13720.4",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "documentURL": "https://samesite-sandbox.glitch.me/",
+      "request": {
+        "url":
+          "https://cdn.glitch.com/e304e580-9956-4cb6-9f62-9e89ad6cd85f%2Fcookie.png?v=1572981153632",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://samesite-sandbox.glitch.me/",
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "strict-origin-when-cross-origin"
+      },
+      "timestamp": 101504.453159,
+      "wallTime": 1595994542.531207,
+      "initiator": { "type": "other" },
+      "type": "Other",
+      "frameId": "447C526AAC595F429B694068BE35F750",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "13720.3",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "date": "Wed, 29 Jul 2020 03:49:02 GMT",
+        "content-type": "application/json; charset=utf-8",
+        "content-length": "57",
+        "x-powered-by": "Express",
+        "strict-transport-security":
+          "max-age=63072000; inlcudeSubdomains; preload",
+        "access-control-allow-origin": "https://googlechromelabs.github.io",
+        "access-control-allow-credentials": "true",
+        "etag": "W/\"39-P/NBn2GNcAA8yGJ1I79HEa1fh8I\""
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "13720.3",
+      "loaderId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "timestamp": 101504.681331,
+      "type": "XHR",
+      "response": {
+        "url": "https://samesite-sandbox.glitch.me/cookies.json",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Wed, 29 Jul 2020 03:49:02 GMT",
+          "status": "200",
+          "x-powered-by": "Express",
+          "etag": "W/\"39-P/NBn2GNcAA8yGJ1I79HEa1fh8I\"",
+          "strict-transport-security":
+            "max-age=63072000; inlcudeSubdomains; preload",
+          "content-type": "application/json; charset=utf-8",
+          "access-control-allow-origin": "https://googlechromelabs.github.io",
+          "access-control-allow-credentials": "true",
+          "content-length": "57"
+        },
+        "mimeType": "application/json",
+        "connectionReused": true,
+        "connectionId": 27,
+        "remoteIPAddress": "54.164.246.13",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 240,
+        "timing": {
+          "requestTime": 101504.450842,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 0.247,
+          "sendEnd": 0.375,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 228.095
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "glitch.com",
+          "sanList": [
+            "glitch.com",
+            "glitch.me",
+            "gomix.com",
+            "*.glitch.com",
+            "gomix.me",
+            "*.gomix.me",
+            "*.glitch.me",
+            "hyperdev.com",
+            "*.hyperdev.com",
+            "*.gomix.com"
+          ],
+          "issuer": "Amazon",
+          "validFrom": 1581984000,
+          "validTo": 1616068800,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Skydiver' log",
+              "logId":
+                "BBD9DFBC1F8A71B593942397AA927B473857950AAB52E81A909664368E1ED185",
+              "timestamp": 1582065086753,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30460221008F85EB81321626E05DFC2D21CD76F747F633F1BB2DDD08EC1B9247F09705CADD022100C40B8B3618B01225F8F1B091FC699C7986178429FF95A475066CF4567575B2CA"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Log Server 2",
+              "logId":
+                "8775BFE7597CF88C43995FBDF36EFF568D475636FF4AB560C1B4EAFF5EA0830F",
+              "timestamp": 1582065086835,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30450221009BD96A9E4B69EAB9CD766C423B14902F48BA85026C8055DFD4166528DDC6C22C02205B4520A3AF7654586FC7718787A8081A3C939D757DEB0FDD32AAE80300B7ABB5"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "13720.3",
+      "timestamp": 101504.68148,
+      "dataLength": 57,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "13720.3",
+      "timestamp": 101504.679942,
+      "encodedDataLength": 315,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "13720.4",
+      "associatedCookies": [],
+      "headers": {
+        "Host": "cdn.glitch.com",
+        "Connection": "keep-alive",
+        "User-Agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "Accept": "image/webp,image/apng,image/*,*/*;q=0.8",
+        "Sec-Fetch-Site": "cross-site",
+        "Sec-Fetch-Mode": "no-cors",
+        "Sec-Fetch-Dest": "image",
+        "Referer": "https://samesite-sandbox.glitch.me/",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "13720.4",
+      "blockedCookies": [],
+      "headers": {
+        "Content-Type": "image/png",
+        "Content-Length": "10010",
+        "Connection": "keep-alive",
+        "Date": "Mon, 22 Jun 2020 10:05:03 GMT",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, HEAD, POST",
+        "Access-Control-Max-Age": "86400",
+        "Cache-Control": "max-age=31536000",
+        "Last-Modified": "Tue, 05 Nov 2019 19:12:33 GMT",
+        "ETag": "\"4fc7568972cffeaa3b02ff05668179d4\"",
+        "Server": "AmazonS3",
+        "X-Cache": "Hit from cloudfront",
+        "Via":
+          "1.1 0cd88f29d8c6e29a267867c45efda9a9.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "SIN52-C2",
+        "X-Amz-Cf-Id":
+          "POKa3J20B_ZaSB17GG2WukHAyh4lRGmfUCfk-PtMyGfmGK6f7VbSYg==",
+        "Age": "3174242"
+      },
+      "headersText":
+        "HTTP/1.1 200 OK\r\nContent-Type: image/png\r\nContent-Length: 10010\r\nConnection: keep-alive\r\nDate: Mon, 22 Jun 2020 10:05:03 GMT\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: GET, HEAD, POST\r\nAccess-Control-Max-Age: 86400\r\nCache-Control: max-age=31536000\r\nLast-Modified: Tue, 05 Nov 2019 19:12:33 GMT\r\nETag: \"4fc7568972cffeaa3b02ff05668179d4\"\r\nServer: AmazonS3\r\nX-Cache: Hit from cloudfront\r\nVia: 1.1 0cd88f29d8c6e29a267867c45efda9a9.cloudfront.net (CloudFront)\r\nX-Amz-Cf-Pop: SIN52-C2\r\nX-Amz-Cf-Id: POKa3J20B_ZaSB17GG2WukHAyh4lRGmfUCfk-PtMyGfmGK6f7VbSYg==\r\nAge: 3174242\r\n\r\n"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "13720.4",
+      "loaderId": "8370893B3D16ACE10B5AA20C4E9069A4",
+      "timestamp": 101504.913027,
+      "type": "Other",
+      "response": {
+        "url":
+          "https://cdn.glitch.com/e304e580-9956-4cb6-9f62-9e89ad6cd85f%2Fcookie.png?v=1572981153632",
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "Date": "Mon, 22 Jun 2020 10:05:03 GMT",
+          "Via":
+            "1.1 0cd88f29d8c6e29a267867c45efda9a9.cloudfront.net (CloudFront)",
+          "Age": "3174242",
+          "X-Cache": "Hit from cloudfront",
+          "Connection": "keep-alive",
+          "Content-Length": "10010",
+          "Last-Modified": "Tue, 05 Nov 2019 19:12:33 GMT",
+          "Server": "AmazonS3",
+          "ETag": "\"4fc7568972cffeaa3b02ff05668179d4\"",
+          "Access-Control-Max-Age": "86400",
+          "Access-Control-Allow-Methods": "GET, HEAD, POST",
+          "Content-Type": "image/png",
+          "Access-Control-Allow-Origin": "*",
+          "Cache-Control": "max-age=31536000",
+          "X-Amz-Cf-Pop": "SIN52-C2",
+          "X-Amz-Cf-Id":
+            "POKa3J20B_ZaSB17GG2WukHAyh4lRGmfUCfk-PtMyGfmGK6f7VbSYg=="
+        },
+        "mimeType": "image/png",
+        "connectionReused": false,
+        "connectionId": 57,
+        "remoteIPAddress": "13.225.5.120",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 587,
+        "timing": {
+          "requestTime": 101504.453423,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.141,
+          "dnsEnd": 19.811,
+          "connectStart": 19.811,
+          "connectEnd": 348.28,
+          "sslStart": 122.99,
+          "sslEnd": 348.267,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 348.382,
+          "sendEnd": 348.576,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 458.679
+        },
+        "protocol": "http/1.1",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "glitch.com",
+          "sanList": [
+            "glitch.com",
+            "glitch.me",
+            "gomix.com",
+            "*.glitch.com",
+            "gomix.me",
+            "*.gomix.me",
+            "*.glitch.me",
+            "hyperdev.com",
+            "*.hyperdev.com",
+            "*.gomix.com"
+          ],
+          "issuer": "Amazon",
+          "validFrom": 1581984000,
+          "validTo": 1616068800,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Skydiver' log",
+              "logId":
+                "BBD9DFBC1F8A71B593942397AA927B473857950AAB52E81A909664368E1ED185",
+              "timestamp": 1582065086753,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30460221008F85EB81321626E05DFC2D21CD76F747F633F1BB2DDD08EC1B9247F09705CADD022100C40B8B3618B01225F8F1B091FC699C7986178429FF95A475066CF4567575B2CA"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Log Server 2",
+              "logId":
+                "8775BFE7597CF88C43995FBDF36EFF568D475636FF4AB560C1B4EAFF5EA0830F",
+              "timestamp": 1582065086835,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData":
+                "30450221009BD96A9E4B69EAB9CD766C423B14902F48BA85026C8055DFD4166528DDC6C22C02205B4520A3AF7654586FC7718787A8081A3C939D757DEB0FDD32AAE80300B7ABB5"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "447C526AAC595F429B694068BE35F750"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "13720.4",
+      "timestamp": 101504.91318,
+      "dataLength": 10010,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "13720.4",
+      "timestamp": 101504.91422,
+      "dataLength": 0,
+      "encodedDataLength": 10010
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "13720.4",
+      "timestamp": 101504.913024,
+      "encodedDataLength": 10597,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "loaderId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "name": "networkAlmostIdle",
+      "timestamp": 101504.452019
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "1CF39B1FEA7835B89AD7BC3742E338C4",
+      "loaderId": "6FD5005E76F02FF80B1A28761D02BA11",
+      "name": "networkIdle",
+      "timestamp": 101504.682521
+    }
+  }
+]

--- a/test/perflogs/www.calibreapp.com.signin.json
+++ b/test/perflogs/www.calibreapp.com.signin.json
@@ -1,0 +1,4227 @@
+[
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "loaderId": "5B231C2DBF4E07FAB75BC671532F8DE7",
+      "name": "commit",
+      "timestamp": 73984.842784
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "loaderId": "5B231C2DBF4E07FAB75BC671532F8DE7",
+      "name": "DOMContentLoaded",
+      "timestamp": 73984.843045
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "loaderId": "5B231C2DBF4E07FAB75BC671532F8DE7",
+      "name": "load",
+      "timestamp": 73984.843528
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "loaderId": "5B231C2DBF4E07FAB75BC671532F8DE7",
+      "name": "networkAlmostIdle",
+      "timestamp": 73984.844294
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "loaderId": "5B231C2DBF4E07FAB75BC671532F8DE7",
+      "name": "networkIdle",
+      "timestamp": 73984.844294
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "documentURL": "https://www.calibreapp.com/sign-in",
+      "request": {
+        "url": "https://www.calibreapp.com/sign-in",
+        "method": "GET",
+        "headers": {
+          "Upgrade-Insecure-Requests": "1",
+          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 73984.919716,
+      "wallTime": 1595909652.40576,
+      "initiator": { "type": "other" },
+      "type": "Document",
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "associatedCookies": [],
+      "headers": {
+        ":method": "GET",
+        ":authority": "www.calibreapp.com",
+        ":scheme": "https",
+        ":path": "/sign-in",
+        "upgrade-insecure-requests": "1",
+        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+        "sec-fetch-site": "none",
+        "sec-fetch-mode": "navigate",
+        "sec-fetch-user": "?1",
+        "sec-fetch-dest": "document",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "loaderId": "5B231C2DBF4E07FAB75BC671532F8DE7",
+      "name": "networkAlmostIdle",
+      "timestamp": 73984.844294
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "loaderId": "5B231C2DBF4E07FAB75BC671532F8DE7",
+      "name": "networkIdle",
+      "timestamp": 73984.844294
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "content-type": "text/html; charset=utf-8",
+        "server": "Cowboy",
+        "date": "Tue, 28 Jul 2020 04:14:12 GMT",
+        "x-frame-options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block",
+        "x-content-type-options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "referrer-policy": "strict-origin-when-cross-origin",
+        "vary": "Accept-Encoding",
+        "content-encoding": "br",
+        "etag": "W/\"a67e751d0404a9456426208e90f9c13e\"",
+        "cache-control": "max-age=0, private, must-revalidate",
+        "set-cookie": "_calibre_app_session=UlhuZzdnMUxvRjdnMFMxajlFeEFlNDJRQjEwbVlHeEdML3Z1ZDRpMzY0ak1henc1clMwWVdJQXJ0RjVvRnhDR081MlFPTFU2Ulh4RUtPcGZhZ0t0Z3h0OFBmQ1dtM3dvTmJidHZnTTRQZEpIOGNmUVhMRHB4TFcra2VpU21uV3VMN1o2YjhlQmlYRnZ4VDBiUXNHdnBBPT0tLVFjYjdWQXo2SUdIZ0FBOERnblhRaXc9PQ%3D%3D--ebff94e1d82babaca5b55404e2e5da785cd12fb8; path=/; secure; HttpOnly",
+        "x-request-id": "f60351bd-7fa5-4d69-a0a8-f1c3e75516b6",
+        "x-runtime": "0.014130",
+        "strict-transport-security": "max-age=31536000; includeSubDomains",
+        "via": "1.1 vegur, 1.1 c9b90fe1dcd0958f352b5816fbce3bbe.cloudfront.net (CloudFront)",
+        "x-cache": "Miss from cloudfront",
+        "x-amz-cf-pop": "SYD4-C2",
+        "x-amz-cf-id": "AM_nam5s20rwAELEIwoTLYPaDR2sB4CT-EILsh7bB39xtovEsVFzVg=="
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "timestamp": 73985.834166,
+      "type": "Document",
+      "response": {
+        "url": "https://www.calibreapp.com/sign-in",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "status": "200",
+          "content-type": "text/html; charset=utf-8",
+          "server": "Cowboy",
+          "date": "Tue, 28 Jul 2020 04:14:12 GMT",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block",
+          "x-content-type-options": "nosniff",
+          "x-download-options": "noopen",
+          "x-permitted-cross-domain-policies": "none",
+          "referrer-policy": "strict-origin-when-cross-origin",
+          "vary": "Accept-Encoding",
+          "content-encoding": "br",
+          "etag": "W/\"a67e751d0404a9456426208e90f9c13e\"",
+          "cache-control": "max-age=0, private, must-revalidate",
+          "set-cookie": "_calibre_app_session=UlhuZzdnMUxvRjdnMFMxajlFeEFlNDJRQjEwbVlHeEdML3Z1ZDRpMzY0ak1henc1clMwWVdJQXJ0RjVvRnhDR081MlFPTFU2Ulh4RUtPcGZhZ0t0Z3h0OFBmQ1dtM3dvTmJidHZnTTRQZEpIOGNmUVhMRHB4TFcra2VpU21uV3VMN1o2YjhlQmlYRnZ4VDBiUXNHdnBBPT0tLVFjYjdWQXo2SUdIZ0FBOERnblhRaXc9PQ%3D%3D--ebff94e1d82babaca5b55404e2e5da785cd12fb8; path=/; secure; HttpOnly",
+          "x-request-id": "f60351bd-7fa5-4d69-a0a8-f1c3e75516b6",
+          "x-runtime": "0.014130",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "via": "1.1 vegur, 1.1 c9b90fe1dcd0958f352b5816fbce3bbe.cloudfront.net (CloudFront)",
+          "x-cache": "Miss from cloudfront",
+          "x-amz-cf-pop": "SYD4-C2",
+          "x-amz-cf-id": "AM_nam5s20rwAELEIwoTLYPaDR2sB4CT-EILsh7bB39xtovEsVFzVg=="
+        },
+        "mimeType": "text/html",
+        "requestHeaders": {
+          ":method": "GET",
+          ":authority": "www.calibreapp.com",
+          ":scheme": "https",
+          ":path": "/sign-in",
+          "upgrade-insecure-requests": "1",
+          "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+          "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+          "sec-fetch-site": "none",
+          "sec-fetch-mode": "navigate",
+          "sec-fetch-user": "?1",
+          "sec-fetch-dest": "document",
+          "accept-encoding": "gzip, deflate, br",
+          "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+        },
+        "connectionReused": false,
+        "connectionId": 38,
+        "remoteIPAddress": "13.226.85.108",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 865,
+        "timing": {
+          "requestTime": 73984.920313,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.146,
+          "dnsEnd": 29.055,
+          "connectStart": 29.055,
+          "connectEnd": 66.84,
+          "sslStart": 45.048,
+          "sslEnd": 66.834,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 67.513,
+          "sendEnd": 67.621,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 911.34
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "calibreapp.com",
+          "sanList": ["calibreapp.com", "www.calibreapp.com"],
+          "issuer": "Amazon",
+          "validFrom": 1589673600,
+          "validTo": 1623931200,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2021' log",
+              "logId": "F65C942FD1773022145418083094568EE34D131933BFDF0C2F200BCC4EF164E3",
+              "timestamp": 1589682688690,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "3044022033B128B4C6A86EEEB7FE1FB41907AE7F54F30B1BBD5F0B4B47269504682752390220195BDDB26B117410F6B71004982A38C76A4DD7953A89B4D92AEE1020A5EFADEB"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2021 Log",
+              "logId": "5CDC4392FEE6AB4544B15E9AD456E61037FBD5FA47DCA17394B25EE6F6C70ECA",
+              "timestamp": 1589682688713,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "3045022100B3CD451308B0FABCC1255F6F24FC9E01600DF6A2FD43FFBED4DC347B54621B29022056A4FC3E0CC26687B94BA44FDCA751240D5FD1CE29B8581202EC49C52A102538"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA"
+    }
+  },
+  {
+    "method": "Page.frameStartedLoading",
+    "params": { "frameId": "5356556406F4EF152D876F82DF1B8FFA" }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "name": "init",
+      "timestamp": 73985.838614
+    }
+  },
+  {
+    "method": "Page.frameNavigated",
+    "params": {
+      "frame": {
+        "id": "5356556406F4EF152D876F82DF1B8FFA",
+        "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+        "url": "https://www.calibreapp.com/sign-in",
+        "securityOrigin": "https://www.calibreapp.com",
+        "mimeType": "text/html"
+      }
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "timestamp": 73985.850105,
+      "dataLength": 13524,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "9836.2",
+      "associatedCookies": [
+        {
+          "blockedReasons": [],
+          "cookie": {
+            "name": "_calibre_app_session",
+            "value": "UlhuZzdnMUxvRjdnMFMxajlFeEFlNDJRQjEwbVlHeEdML3Z1ZDRpMzY0ak1henc1clMwWVdJQXJ0RjVvRnhDR081MlFPTFU2Ulh4RUtPcGZhZ0t0Z3h0OFBmQ1dtM3dvTmJidHZnTTRQZEpIOGNmUVhMRHB4TFcra2VpU21uV3VMN1o2YjhlQmlYRnZ4VDBiUXNHdnBBPT0tLVFjYjdWQXo2SUdIZ0FBOERnblhRaXc9PQ%3D%3D--ebff94e1d82babaca5b55404e2e5da785cd12fb8",
+            "domain": "www.calibreapp.com",
+            "path": "/",
+            "expires": -1,
+            "size": 306,
+            "httpOnly": true,
+            "secure": true,
+            "session": true,
+            "priority": "Medium"
+          }
+        }
+      ],
+      "headers": {
+        ":method": "GET",
+        ":authority": "www.calibreapp.com",
+        ":scheme": "https",
+        ":path": "/fonts/Calibre-Regular.woff2",
+        "origin": "https://www.calibreapp.com",
+        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept": "*/*",
+        "sec-fetch-site": "same-origin",
+        "sec-fetch-mode": "cors",
+        "sec-fetch-dest": "font",
+        "referer": "https://www.calibreapp.com/sign-in",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
+        "cookie": "_calibre_app_session=UlhuZzdnMUxvRjdnMFMxajlFeEFlNDJRQjEwbVlHeEdML3Z1ZDRpMzY0ak1henc1clMwWVdJQXJ0RjVvRnhDR081MlFPTFU2Ulh4RUtPcGZhZ0t0Z3h0OFBmQ1dtM3dvTmJidHZnTTRQZEpIOGNmUVhMRHB4TFcra2VpU21uV3VMN1o2YjhlQmlYRnZ4VDBiUXNHdnBBPT0tLVFjYjdWQXo2SUdIZ0FBOERnblhRaXc9PQ%3D%3D--ebff94e1d82babaca5b55404e2e5da785cd12fb8"
+      }
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "9836.2",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "documentURL": "https://www.calibreapp.com/sign-in",
+      "request": {
+        "url": "https://www.calibreapp.com/fonts/Calibre-Regular.woff2",
+        "method": "GET",
+        "headers": {
+          "Origin": "https://www.calibreapp.com",
+          "Referer": "https://www.calibreapp.com/sign-in",
+          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isLinkPreload": true
+      },
+      "timestamp": 73985.850923,
+      "wallTime": 1595909653.336874,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.calibreapp.com/sign-in",
+        "lineNumber": 29
+      },
+      "type": "Font",
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "9836.3",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "documentURL": "https://www.calibreapp.com/sign-in",
+      "request": {
+        "url": "https://www.calibreapp.com/fonts/Calibre-Semibold.woff2",
+        "method": "GET",
+        "headers": {
+          "Origin": "https://www.calibreapp.com",
+          "Referer": "https://www.calibreapp.com/sign-in",
+          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isLinkPreload": true
+      },
+      "timestamp": 73985.851161,
+      "wallTime": 1595909653.337112,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.calibreapp.com/sign-in",
+        "lineNumber": 30
+      },
+      "type": "Font",
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "9836.4",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "documentURL": "https://www.calibreapp.com/sign-in",
+      "request": {
+        "url": "https://www.calibreapp.com/fonts/Calibre-Medium.woff2",
+        "method": "GET",
+        "headers": {
+          "Origin": "https://www.calibreapp.com",
+          "Referer": "https://www.calibreapp.com/sign-in",
+          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "strict-origin-when-cross-origin",
+        "isLinkPreload": true
+      },
+      "timestamp": 73985.851327,
+      "wallTime": 1595909653.337278,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.calibreapp.com/sign-in",
+        "lineNumber": 31
+      },
+      "type": "Font",
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "timestamp": 73985.832661,
+      "encodedDataLength": 6550,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "9836.3",
+      "associatedCookies": [
+        {
+          "blockedReasons": [],
+          "cookie": {
+            "name": "_calibre_app_session",
+            "value": "UlhuZzdnMUxvRjdnMFMxajlFeEFlNDJRQjEwbVlHeEdML3Z1ZDRpMzY0ak1henc1clMwWVdJQXJ0RjVvRnhDR081MlFPTFU2Ulh4RUtPcGZhZ0t0Z3h0OFBmQ1dtM3dvTmJidHZnTTRQZEpIOGNmUVhMRHB4TFcra2VpU21uV3VMN1o2YjhlQmlYRnZ4VDBiUXNHdnBBPT0tLVFjYjdWQXo2SUdIZ0FBOERnblhRaXc9PQ%3D%3D--ebff94e1d82babaca5b55404e2e5da785cd12fb8",
+            "domain": "www.calibreapp.com",
+            "path": "/",
+            "expires": -1,
+            "size": 306,
+            "httpOnly": true,
+            "secure": true,
+            "session": true,
+            "priority": "Medium"
+          }
+        }
+      ],
+      "headers": {
+        ":method": "GET",
+        ":authority": "www.calibreapp.com",
+        ":scheme": "https",
+        ":path": "/fonts/Calibre-Semibold.woff2",
+        "origin": "https://www.calibreapp.com",
+        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept": "*/*",
+        "sec-fetch-site": "same-origin",
+        "sec-fetch-mode": "cors",
+        "sec-fetch-dest": "font",
+        "referer": "https://www.calibreapp.com/sign-in",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
+        "cookie": "_calibre_app_session=UlhuZzdnMUxvRjdnMFMxajlFeEFlNDJRQjEwbVlHeEdML3Z1ZDRpMzY0ak1henc1clMwWVdJQXJ0RjVvRnhDR081MlFPTFU2Ulh4RUtPcGZhZ0t0Z3h0OFBmQ1dtM3dvTmJidHZnTTRQZEpIOGNmUVhMRHB4TFcra2VpU21uV3VMN1o2YjhlQmlYRnZ4VDBiUXNHdnBBPT0tLVFjYjdWQXo2SUdIZ0FBOERnblhRaXc9PQ%3D%3D--ebff94e1d82babaca5b55404e2e5da785cd12fb8"
+      }
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "9836.5",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "documentURL": "https://www.calibreapp.com/sign-in",
+      "request": {
+        "url": "https://www.calibreapp.com/assets/sign_up_in-8b32538e54b23b40f8fd45c28abdcee2e2d023bd7e01ddf2033d5f781afae9dc.css",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.calibreapp.com/sign-in",
+          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "VeryHigh",
+        "referrerPolicy": "strict-origin-when-cross-origin"
+      },
+      "timestamp": 73985.852332,
+      "wallTime": 1595909653.338283,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.calibreapp.com/sign-in",
+        "lineNumber": 5
+      },
+      "type": "Stylesheet",
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "9836.6",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "documentURL": "https://www.calibreapp.com/sign-in",
+      "request": {
+        "url": "https://d2wy8f7a9ursnm.cloudfront.net/v7/bugsnag.min.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.calibreapp.com/",
+          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "strict-origin-when-cross-origin"
+      },
+      "timestamp": 73985.852514,
+      "wallTime": 1595909653.338465,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.calibreapp.com/sign-in",
+        "lineNumber": 19
+      },
+      "type": "Script",
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "9836.7",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "documentURL": "https://www.calibreapp.com/sign-in",
+      "request": {
+        "url": "https://www.calibreapp.com/webpack/sign_up_in-980d8a42e50000804fc6.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.calibreapp.com/sign-in",
+          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "strict-origin-when-cross-origin"
+      },
+      "timestamp": 73985.852746,
+      "wallTime": 1595909653.338698,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.calibreapp.com/sign-in",
+        "lineNumber": 32
+      },
+      "type": "Script",
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "9836.4",
+      "associatedCookies": [
+        {
+          "blockedReasons": [],
+          "cookie": {
+            "name": "_calibre_app_session",
+            "value": "UlhuZzdnMUxvRjdnMFMxajlFeEFlNDJRQjEwbVlHeEdML3Z1ZDRpMzY0ak1henc1clMwWVdJQXJ0RjVvRnhDR081MlFPTFU2Ulh4RUtPcGZhZ0t0Z3h0OFBmQ1dtM3dvTmJidHZnTTRQZEpIOGNmUVhMRHB4TFcra2VpU21uV3VMN1o2YjhlQmlYRnZ4VDBiUXNHdnBBPT0tLVFjYjdWQXo2SUdIZ0FBOERnblhRaXc9PQ%3D%3D--ebff94e1d82babaca5b55404e2e5da785cd12fb8",
+            "domain": "www.calibreapp.com",
+            "path": "/",
+            "expires": -1,
+            "size": 306,
+            "httpOnly": true,
+            "secure": true,
+            "session": true,
+            "priority": "Medium"
+          }
+        }
+      ],
+      "headers": {
+        ":method": "GET",
+        ":authority": "www.calibreapp.com",
+        ":scheme": "https",
+        ":path": "/fonts/Calibre-Medium.woff2",
+        "origin": "https://www.calibreapp.com",
+        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept": "*/*",
+        "sec-fetch-site": "same-origin",
+        "sec-fetch-mode": "cors",
+        "sec-fetch-dest": "font",
+        "referer": "https://www.calibreapp.com/sign-in",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
+        "cookie": "_calibre_app_session=UlhuZzdnMUxvRjdnMFMxajlFeEFlNDJRQjEwbVlHeEdML3Z1ZDRpMzY0ak1henc1clMwWVdJQXJ0RjVvRnhDR081MlFPTFU2Ulh4RUtPcGZhZ0t0Z3h0OFBmQ1dtM3dvTmJidHZnTTRQZEpIOGNmUVhMRHB4TFcra2VpU21uV3VMN1o2YjhlQmlYRnZ4VDBiUXNHdnBBPT0tLVFjYjdWQXo2SUdIZ0FBOERnblhRaXc9PQ%3D%3D--ebff94e1d82babaca5b55404e2e5da785cd12fb8"
+      }
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "9836.5",
+      "associatedCookies": [
+        {
+          "blockedReasons": [],
+          "cookie": {
+            "name": "_calibre_app_session",
+            "value": "UlhuZzdnMUxvRjdnMFMxajlFeEFlNDJRQjEwbVlHeEdML3Z1ZDRpMzY0ak1henc1clMwWVdJQXJ0RjVvRnhDR081MlFPTFU2Ulh4RUtPcGZhZ0t0Z3h0OFBmQ1dtM3dvTmJidHZnTTRQZEpIOGNmUVhMRHB4TFcra2VpU21uV3VMN1o2YjhlQmlYRnZ4VDBiUXNHdnBBPT0tLVFjYjdWQXo2SUdIZ0FBOERnblhRaXc9PQ%3D%3D--ebff94e1d82babaca5b55404e2e5da785cd12fb8",
+            "domain": "www.calibreapp.com",
+            "path": "/",
+            "expires": -1,
+            "size": 306,
+            "httpOnly": true,
+            "secure": true,
+            "session": true,
+            "priority": "Medium"
+          }
+        }
+      ],
+      "headers": {
+        ":method": "GET",
+        ":authority": "www.calibreapp.com",
+        ":scheme": "https",
+        ":path": "/assets/sign_up_in-8b32538e54b23b40f8fd45c28abdcee2e2d023bd7e01ddf2033d5f781afae9dc.css",
+        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept": "text/css,*/*;q=0.1",
+        "sec-fetch-site": "same-origin",
+        "sec-fetch-mode": "no-cors",
+        "sec-fetch-dest": "style",
+        "referer": "https://www.calibreapp.com/sign-in",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
+        "cookie": "_calibre_app_session=UlhuZzdnMUxvRjdnMFMxajlFeEFlNDJRQjEwbVlHeEdML3Z1ZDRpMzY0ak1henc1clMwWVdJQXJ0RjVvRnhDR081MlFPTFU2Ulh4RUtPcGZhZ0t0Z3h0OFBmQ1dtM3dvTmJidHZnTTRQZEpIOGNmUVhMRHB4TFcra2VpU21uV3VMN1o2YjhlQmlYRnZ4VDBiUXNHdnBBPT0tLVFjYjdWQXo2SUdIZ0FBOERnblhRaXc9PQ%3D%3D--ebff94e1d82babaca5b55404e2e5da785cd12fb8"
+      }
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "9836.7",
+      "associatedCookies": [
+        {
+          "blockedReasons": [],
+          "cookie": {
+            "name": "_calibre_app_session",
+            "value": "UlhuZzdnMUxvRjdnMFMxajlFeEFlNDJRQjEwbVlHeEdML3Z1ZDRpMzY0ak1henc1clMwWVdJQXJ0RjVvRnhDR081MlFPTFU2Ulh4RUtPcGZhZ0t0Z3h0OFBmQ1dtM3dvTmJidHZnTTRQZEpIOGNmUVhMRHB4TFcra2VpU21uV3VMN1o2YjhlQmlYRnZ4VDBiUXNHdnBBPT0tLVFjYjdWQXo2SUdIZ0FBOERnblhRaXc9PQ%3D%3D--ebff94e1d82babaca5b55404e2e5da785cd12fb8",
+            "domain": "www.calibreapp.com",
+            "path": "/",
+            "expires": -1,
+            "size": 306,
+            "httpOnly": true,
+            "secure": true,
+            "session": true,
+            "priority": "Medium"
+          }
+        }
+      ],
+      "headers": {
+        ":method": "GET",
+        ":authority": "www.calibreapp.com",
+        ":scheme": "https",
+        ":path": "/webpack/sign_up_in-980d8a42e50000804fc6.js",
+        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept": "*/*",
+        "sec-fetch-site": "same-origin",
+        "sec-fetch-mode": "no-cors",
+        "sec-fetch-dest": "script",
+        "referer": "https://www.calibreapp.com/sign-in",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
+        "cookie": "_calibre_app_session=UlhuZzdnMUxvRjdnMFMxajlFeEFlNDJRQjEwbVlHeEdML3Z1ZDRpMzY0ak1henc1clMwWVdJQXJ0RjVvRnhDR081MlFPTFU2Ulh4RUtPcGZhZ0t0Z3h0OFBmQ1dtM3dvTmJidHZnTTRQZEpIOGNmUVhMRHB4TFcra2VpU21uV3VMN1o2YjhlQmlYRnZ4VDBiUXNHdnBBPT0tLVFjYjdWQXo2SUdIZ0FBOERnblhRaXc9PQ%3D%3D--ebff94e1d82babaca5b55404e2e5da785cd12fb8"
+      }
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "9836.6",
+      "associatedCookies": [],
+      "headers": {
+        "Host": "d2wy8f7a9ursnm.cloudfront.net",
+        "Connection": "keep-alive",
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "Accept": "*/*",
+        "Sec-Fetch-Site": "cross-site",
+        "Sec-Fetch-Mode": "no-cors",
+        "Sec-Fetch-Dest": "script",
+        "Referer": "https://www.calibreapp.com/",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Accept-Language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "9836.6",
+      "blockedCookies": [],
+      "headers": {
+        "Content-Type": "application/javascript; charset=UTF-8",
+        "Transfer-Encoding": "chunked",
+        "Connection": "keep-alive",
+        "Date": "Wed, 22 Jul 2020 10:15:17 GMT",
+        "Last-Modified": "Wed, 22 Jul 2020 10:15:00 GMT",
+        "Cache-Control": "public, max-age=315360000",
+        "Server": "AmazonS3",
+        "Content-Encoding": "gzip",
+        "Vary": "Accept-Encoding",
+        "X-Cache": "Hit from cloudfront",
+        "Via": "1.1 5cee5dc5c7fda671aef18544ce05239e.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "SYD4-C1",
+        "X-Amz-Cf-Id": "DWUpmc_0jyi4YVrd4F1T2iTKVnoN7tayeoJ9EjEDsNrucBafW_kkPQ==",
+        "Age": "496737"
+      },
+      "headersText": "HTTP/1.1 200 OK\r\nContent-Type: application/javascript; charset=UTF-8\r\nTransfer-Encoding: chunked\r\nConnection: keep-alive\r\nDate: Wed, 22 Jul 2020 10:15:17 GMT\r\nLast-Modified: Wed, 22 Jul 2020 10:15:00 GMT\r\nCache-Control: public, max-age=315360000\r\nServer: AmazonS3\r\nContent-Encoding: gzip\r\nVary: Accept-Encoding\r\nX-Cache: Hit from cloudfront\r\nVia: 1.1 5cee5dc5c7fda671aef18544ce05239e.cloudfront.net (CloudFront)\r\nX-Amz-Cf-Pop: SYD4-C1\r\nX-Amz-Cf-Id: DWUpmc_0jyi4YVrd4F1T2iTKVnoN7tayeoJ9EjEDsNrucBafW_kkPQ==\r\nAge: 496737\r\n\r\n"
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "9836.6",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "timestamp": 73985.92721,
+      "type": "Script",
+      "response": {
+        "url": "https://d2wy8f7a9ursnm.cloudfront.net/v7/bugsnag.min.js",
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "Date": "Wed, 22 Jul 2020 10:15:17 GMT",
+          "Content-Encoding": "gzip",
+          "Connection": "keep-alive",
+          "Last-Modified": "Wed, 22 Jul 2020 10:15:00 GMT",
+          "Server": "AmazonS3",
+          "Age": "496737",
+          "Vary": "Accept-Encoding",
+          "X-Cache": "Hit from cloudfront",
+          "Content-Type": "application/javascript; charset=UTF-8",
+          "Via": "1.1 5cee5dc5c7fda671aef18544ce05239e.cloudfront.net (CloudFront)",
+          "Cache-Control": "public, max-age=315360000",
+          "Transfer-Encoding": "chunked",
+          "X-Amz-Cf-Pop": "SYD4-C1",
+          "X-Amz-Cf-Id": "DWUpmc_0jyi4YVrd4F1T2iTKVnoN7tayeoJ9EjEDsNrucBafW_kkPQ=="
+        },
+        "mimeType": "application/javascript",
+        "connectionReused": false,
+        "connectionId": 73,
+        "remoteIPAddress": "99.86.211.168",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 522,
+        "timing": {
+          "requestTime": 73985.853245,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.455,
+          "dnsEnd": 22.182,
+          "connectStart": 22.182,
+          "connectEnd": 57.548,
+          "sslStart": 33.828,
+          "sslEnd": 57.542,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 57.615,
+          "sendEnd": 57.686,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 73.042
+        },
+        "protocol": "http/1.1",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "*.cloudfront.net",
+          "sanList": ["cloudfront.net", "*.cloudfront.net"],
+          "issuer": "DigiCert Global CA G2",
+          "validFrom": 1590451200,
+          "validTo": 1619006400,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2021' log",
+              "logId": "F65C942FD1773022145418083094568EE34D131933BFDF0C2F200BCC4EF164E3",
+              "timestamp": 1590535362469,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "3045022100C62DA945D281FDDA9FF3F8A418B44D2F7C2360B56AB951889C381B36F8A9F21D022000E2FCDEBC910829468608895B62D4453E91DD3976B7A6E4AED4D23850E9C7D0"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2021 Log",
+              "logId": "5CDC4392FEE6AB4544B15E9AD456E61037FBD5FA47DCA17394B25EE6F6C70ECA",
+              "timestamp": 1590535362464,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "30450220356C911FB32279F2659553CF3A36D7ACDEA1F4B1A92EDD460D96FF1BDA934EE8022100EEED9337BA12DB44677E09A45FD6666C7B02B8631FB6BF915395B6F9D6FD452D"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.6",
+      "timestamp": 73985.927356,
+      "dataLength": 39565,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.6",
+      "timestamp": 73985.928996,
+      "dataLength": 0,
+      "encodedDataLength": 12305
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "9836.6",
+      "timestamp": 73985.927095,
+      "encodedDataLength": 12827,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "9836.7",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "content-type": "application/javascript",
+        "content-length": "2143",
+        "server": "Cowboy",
+        "date": "Tue, 28 Jul 2020 04:14:13 GMT",
+        "last-modified": "Tue, 28 Jul 2020 00:09:01 GMT",
+        "cache-control": "public, s-maxage=31536000, maxage=15552000",
+        "expires": "Wed, 28 Jul 2021 00:10:59 +0000",
+        "access-control-allow-origin": "*",
+        "content-encoding": "gzip",
+        "vary": "Accept-Encoding",
+        "strict-transport-security": "max-age=31536000; includeSubDomains",
+        "via": "1.1 vegur, 1.1 c9b90fe1dcd0958f352b5816fbce3bbe.cloudfront.net (CloudFront)",
+        "x-cache": "Miss from cloudfront",
+        "x-amz-cf-pop": "SYD4-C2",
+        "x-amz-cf-id": "wEORa-HAJlS8FLnqz70LD-eGYDO23IL8YITtCUTf_UCSzXZoj9Tixg=="
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "9836.7",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "timestamp": 73986.688967,
+      "type": "Script",
+      "response": {
+        "url": "https://www.calibreapp.com/webpack/sign_up_in-980d8a42e50000804fc6.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Tue, 28 Jul 2020 04:14:13 GMT",
+          "content-encoding": "gzip",
+          "vary": "Accept-Encoding",
+          "x-amz-cf-pop": "SYD4-C2",
+          "x-cache": "Miss from cloudfront",
+          "status": "200",
+          "content-length": "2143",
+          "access-control-allow-origin": "*",
+          "last-modified": "Tue, 28 Jul 2020 00:09:01 GMT",
+          "server": "Cowboy",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "content-type": "application/javascript",
+          "via": "1.1 vegur, 1.1 c9b90fe1dcd0958f352b5816fbce3bbe.cloudfront.net (CloudFront)",
+          "cache-control": "public, s-maxage=31536000, maxage=15552000",
+          "x-amz-cf-id": "wEORa-HAJlS8FLnqz70LD-eGYDO23IL8YITtCUTf_UCSzXZoj9Tixg==",
+          "expires": "Wed, 28 Jul 2021 00:10:59 +0000"
+        },
+        "mimeType": "application/javascript",
+        "connectionReused": true,
+        "connectionId": 38,
+        "remoteIPAddress": "13.226.85.108",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 446,
+        "timing": {
+          "requestTime": 73985.853548,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 0.789,
+          "sendEnd": 0.985,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 833.811
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "calibreapp.com",
+          "sanList": ["calibreapp.com", "www.calibreapp.com"],
+          "issuer": "Amazon",
+          "validFrom": 1589673600,
+          "validTo": 1623931200,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2021' log",
+              "logId": "F65C942FD1773022145418083094568EE34D131933BFDF0C2F200BCC4EF164E3",
+              "timestamp": 1589682688690,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "3044022033B128B4C6A86EEEB7FE1FB41907AE7F54F30B1BBD5F0B4B47269504682752390220195BDDB26B117410F6B71004982A38C76A4DD7953A89B4D92AEE1020A5EFADEB"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2021 Log",
+              "logId": "5CDC4392FEE6AB4544B15E9AD456E61037FBD5FA47DCA17394B25EE6F6C70ECA",
+              "timestamp": 1589682688713,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "3045022100B3CD451308B0FABCC1255F6F24FC9E01600DF6A2FD43FFBED4DC347B54621B29022056A4FC3E0CC26687B94BA44FDCA751240D5FD1CE29B8581202EC49C52A102538"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.7",
+      "timestamp": 73986.689127,
+      "dataLength": 5407,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.7",
+      "timestamp": 73986.689519,
+      "dataLength": 0,
+      "encodedDataLength": 2161
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "9836.7",
+      "timestamp": 73986.687826,
+      "encodedDataLength": 2607,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "9836.4",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "content-type": "application/font-woff2",
+        "content-length": "37457",
+        "server": "Cowboy",
+        "date": "Tue, 28 Jul 2020 04:14:13 GMT",
+        "last-modified": "Mon, 27 Jul 2020 23:40:48 GMT",
+        "cache-control": "public, s-maxage=31536000, maxage=15552000, no-transform",
+        "expires": "Wed, 28 Jul 2021 00:10:59 +0000",
+        "access-control-allow-origin": "*",
+        "strict-transport-security": "max-age=31536000; includeSubDomains",
+        "via": "1.1 vegur, 1.1 c9b90fe1dcd0958f352b5816fbce3bbe.cloudfront.net (CloudFront)",
+        "x-cache": "Miss from cloudfront",
+        "x-amz-cf-pop": "SYD4-C2",
+        "x-amz-cf-id": "nEtEwk8VhDxFedrj60sOQHftzVjBm1RkGR5g0i4c45EaxfhD91WDrw=="
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "9836.4",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "timestamp": 73986.872757,
+      "type": "Font",
+      "response": {
+        "url": "https://www.calibreapp.com/fonts/Calibre-Medium.woff2",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Tue, 28 Jul 2020 04:14:13 GMT",
+          "via": "1.1 vegur, 1.1 c9b90fe1dcd0958f352b5816fbce3bbe.cloudfront.net (CloudFront)",
+          "last-modified": "Mon, 27 Jul 2020 23:40:48 GMT",
+          "server": "Cowboy",
+          "x-amz-cf-pop": "SYD4-C2",
+          "status": "200",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "x-cache": "Miss from cloudfront",
+          "content-type": "application/font-woff2",
+          "access-control-allow-origin": "*",
+          "cache-control": "public, s-maxage=31536000, maxage=15552000, no-transform",
+          "content-length": "37457",
+          "x-amz-cf-id": "nEtEwk8VhDxFedrj60sOQHftzVjBm1RkGR5g0i4c45EaxfhD91WDrw==",
+          "expires": "Wed, 28 Jul 2021 00:10:59 +0000"
+        },
+        "mimeType": "application/font-woff2",
+        "connectionReused": true,
+        "connectionId": 38,
+        "remoteIPAddress": "13.226.85.108",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 421,
+        "timing": {
+          "requestTime": 73985.85221,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 0.337,
+          "sendEnd": 1.126,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 1019.946
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "calibreapp.com",
+          "sanList": ["calibreapp.com", "www.calibreapp.com"],
+          "issuer": "Amazon",
+          "validFrom": 1589673600,
+          "validTo": 1623931200,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2021' log",
+              "logId": "F65C942FD1773022145418083094568EE34D131933BFDF0C2F200BCC4EF164E3",
+              "timestamp": 1589682688690,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "3044022033B128B4C6A86EEEB7FE1FB41907AE7F54F30B1BBD5F0B4B47269504682752390220195BDDB26B117410F6B71004982A38C76A4DD7953A89B4D92AEE1020A5EFADEB"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2021 Log",
+              "logId": "5CDC4392FEE6AB4544B15E9AD456E61037FBD5FA47DCA17394B25EE6F6C70ECA",
+              "timestamp": 1589682688713,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "3045022100B3CD451308B0FABCC1255F6F24FC9E01600DF6A2FD43FFBED4DC347B54621B29022056A4FC3E0CC26687B94BA44FDCA751240D5FD1CE29B8581202EC49C52A102538"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.4",
+      "timestamp": 73986.874696,
+      "dataLength": 13882,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.4",
+      "timestamp": 73986.878186,
+      "dataLength": 16366,
+      "encodedDataLength": 13900
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.4",
+      "timestamp": 73986.881653,
+      "dataLength": 7209,
+      "encodedDataLength": 16384
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.4",
+      "timestamp": 73986.882006,
+      "dataLength": 0,
+      "encodedDataLength": 7227
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "9836.4",
+      "timestamp": 73986.881603,
+      "encodedDataLength": 37932,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "9836.3",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "content-type": "application/font-woff2",
+        "content-length": "40517",
+        "server": "Cowboy",
+        "date": "Tue, 28 Jul 2020 04:14:13 GMT",
+        "last-modified": "Mon, 27 Jul 2020 23:40:48 GMT",
+        "cache-control": "public, s-maxage=31536000, maxage=15552000, no-transform",
+        "expires": "Wed, 28 Jul 2021 00:10:59 +0000",
+        "access-control-allow-origin": "*",
+        "strict-transport-security": "max-age=31536000; includeSubDomains",
+        "via": "1.1 vegur, 1.1 c9b90fe1dcd0958f352b5816fbce3bbe.cloudfront.net (CloudFront)",
+        "x-cache": "Miss from cloudfront",
+        "x-amz-cf-pop": "SYD4-C2",
+        "x-amz-cf-id": "aYPi1I9sNcA5Dps5XWtAm_GOZIKzjYWJKXUnsu0ev018QnlN5FFlzA=="
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "9836.3",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "timestamp": 73986.889221,
+      "type": "Font",
+      "response": {
+        "url": "https://www.calibreapp.com/fonts/Calibre-Semibold.woff2",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Tue, 28 Jul 2020 04:14:13 GMT",
+          "via": "1.1 vegur, 1.1 c9b90fe1dcd0958f352b5816fbce3bbe.cloudfront.net (CloudFront)",
+          "last-modified": "Mon, 27 Jul 2020 23:40:48 GMT",
+          "server": "Cowboy",
+          "x-amz-cf-pop": "SYD4-C2",
+          "status": "200",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "x-cache": "Miss from cloudfront",
+          "content-type": "application/font-woff2",
+          "access-control-allow-origin": "*",
+          "cache-control": "public, s-maxage=31536000, maxage=15552000, no-transform",
+          "content-length": "40517",
+          "x-amz-cf-id": "aYPi1I9sNcA5Dps5XWtAm_GOZIKzjYWJKXUnsu0ev018QnlN5FFlzA==",
+          "expires": "Wed, 28 Jul 2021 00:10:59 +0000"
+        },
+        "mimeType": "application/font-woff2",
+        "connectionReused": true,
+        "connectionId": 38,
+        "remoteIPAddress": "13.226.85.108",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 422,
+        "timing": {
+          "requestTime": 73985.851783,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 0.668,
+          "sendEnd": 1.532,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 1036.501
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "calibreapp.com",
+          "sanList": ["calibreapp.com", "www.calibreapp.com"],
+          "issuer": "Amazon",
+          "validFrom": 1589673600,
+          "validTo": 1623931200,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2021' log",
+              "logId": "F65C942FD1773022145418083094568EE34D131933BFDF0C2F200BCC4EF164E3",
+              "timestamp": 1589682688690,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "3044022033B128B4C6A86EEEB7FE1FB41907AE7F54F30B1BBD5F0B4B47269504682752390220195BDDB26B117410F6B71004982A38C76A4DD7953A89B4D92AEE1020A5EFADEB"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2021 Log",
+              "logId": "5CDC4392FEE6AB4544B15E9AD456E61037FBD5FA47DCA17394B25EE6F6C70ECA",
+              "timestamp": 1589682688713,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "3045022100B3CD451308B0FABCC1255F6F24FC9E01600DF6A2FD43FFBED4DC347B54621B29022056A4FC3E0CC26687B94BA44FDCA751240D5FD1CE29B8581202EC49C52A102538"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.3",
+      "timestamp": 73986.890786,
+      "dataLength": 15954,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.3",
+      "timestamp": 73986.895115,
+      "dataLength": 24563,
+      "encodedDataLength": 15981
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.3",
+      "timestamp": 73986.895358,
+      "dataLength": 0,
+      "encodedDataLength": 24599
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "9836.3",
+      "timestamp": 73986.895084,
+      "encodedDataLength": 41002,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "9836.2",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "content-type": "application/font-woff2",
+        "content-length": "38213",
+        "server": "Cowboy",
+        "date": "Tue, 28 Jul 2020 04:14:13 GMT",
+        "last-modified": "Mon, 27 Jul 2020 23:40:48 GMT",
+        "cache-control": "public, s-maxage=31536000, maxage=15552000, no-transform",
+        "expires": "Wed, 28 Jul 2021 00:10:59 +0000",
+        "access-control-allow-origin": "*",
+        "strict-transport-security": "max-age=31536000; includeSubDomains",
+        "via": "1.1 vegur, 1.1 c9b90fe1dcd0958f352b5816fbce3bbe.cloudfront.net (CloudFront)",
+        "x-cache": "Miss from cloudfront",
+        "x-amz-cf-pop": "SYD4-C2",
+        "x-amz-cf-id": "7pz_MSU5oCIToVuRHxTE6Uqa7G8lRFitYMfT7bv5tLI28HE4rWm60Q=="
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "9836.2",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "timestamp": 73986.900441,
+      "type": "Font",
+      "response": {
+        "url": "https://www.calibreapp.com/fonts/Calibre-Regular.woff2",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Tue, 28 Jul 2020 04:14:13 GMT",
+          "via": "1.1 vegur, 1.1 c9b90fe1dcd0958f352b5816fbce3bbe.cloudfront.net (CloudFront)",
+          "last-modified": "Mon, 27 Jul 2020 23:40:48 GMT",
+          "server": "Cowboy",
+          "x-amz-cf-pop": "SYD4-C2",
+          "status": "200",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "x-cache": "Miss from cloudfront",
+          "content-type": "application/font-woff2",
+          "access-control-allow-origin": "*",
+          "cache-control": "public, s-maxage=31536000, maxage=15552000, no-transform",
+          "content-length": "38213",
+          "x-amz-cf-id": "7pz_MSU5oCIToVuRHxTE6Uqa7G8lRFitYMfT7bv5tLI28HE4rWm60Q==",
+          "expires": "Wed, 28 Jul 2021 00:10:59 +0000"
+        },
+        "mimeType": "application/font-woff2",
+        "connectionReused": true,
+        "connectionId": 38,
+        "remoteIPAddress": "13.226.85.108",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 422,
+        "timing": {
+          "requestTime": 73985.851265,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 0.23,
+          "sendEnd": 1.112,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 1048.25
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "calibreapp.com",
+          "sanList": ["calibreapp.com", "www.calibreapp.com"],
+          "issuer": "Amazon",
+          "validFrom": 1589673600,
+          "validTo": 1623931200,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2021' log",
+              "logId": "F65C942FD1773022145418083094568EE34D131933BFDF0C2F200BCC4EF164E3",
+              "timestamp": 1589682688690,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "3044022033B128B4C6A86EEEB7FE1FB41907AE7F54F30B1BBD5F0B4B47269504682752390220195BDDB26B117410F6B71004982A38C76A4DD7953A89B4D92AEE1020A5EFADEB"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2021 Log",
+              "logId": "5CDC4392FEE6AB4544B15E9AD456E61037FBD5FA47DCA17394B25EE6F6C70ECA",
+              "timestamp": 1589682688713,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "3045022100B3CD451308B0FABCC1255F6F24FC9E01600DF6A2FD43FFBED4DC347B54621B29022056A4FC3E0CC26687B94BA44FDCA751240D5FD1CE29B8581202EC49C52A102538"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.2",
+      "timestamp": 73986.903143,
+      "dataLength": 32310,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.2",
+      "timestamp": 73986.908113,
+      "dataLength": 5903,
+      "encodedDataLength": 32346
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "9836.5",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "content-type": "text/css",
+        "content-length": "1734",
+        "server": "Cowboy",
+        "date": "Tue, 28 Jul 2020 04:14:14 GMT",
+        "last-modified": "Thu, 18 Jun 2020 04:52:29 GMT",
+        "cache-control": "public, max-age=86400",
+        "content-encoding": "gzip",
+        "strict-transport-security": "max-age=31536000; includeSubDomains",
+        "via": "1.1 vegur, 1.1 c9b90fe1dcd0958f352b5816fbce3bbe.cloudfront.net (CloudFront)",
+        "vary": "Accept-Encoding",
+        "x-cache": "Miss from cloudfront",
+        "x-amz-cf-pop": "SYD4-C2",
+        "x-amz-cf-id": "65B6zocFB9o0byQIYWsWkWqrggv8nJIFUFU7X3R4Hd83Q4-9yKJSQQ=="
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "9836.5",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "timestamp": 73986.909561,
+      "type": "Stylesheet",
+      "response": {
+        "url": "https://www.calibreapp.com/assets/sign_up_in-8b32538e54b23b40f8fd45c28abdcee2e2d023bd7e01ddf2033d5f781afae9dc.css",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Tue, 28 Jul 2020 04:14:14 GMT",
+          "content-encoding": "gzip",
+          "last-modified": "Thu, 18 Jun 2020 04:52:29 GMT",
+          "server": "Cowboy",
+          "x-amz-cf-pop": "SYD4-C2",
+          "vary": "Accept-Encoding",
+          "x-cache": "Miss from cloudfront",
+          "content-type": "text/css",
+          "status": "200",
+          "cache-control": "public, max-age=86400",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "content-length": "1734",
+          "via": "1.1 vegur, 1.1 c9b90fe1dcd0958f352b5816fbce3bbe.cloudfront.net (CloudFront)",
+          "x-amz-cf-id": "65B6zocFB9o0byQIYWsWkWqrggv8nJIFUFU7X3R4Hd83Q4-9yKJSQQ=="
+        },
+        "mimeType": "text/css",
+        "connectionReused": true,
+        "connectionId": 38,
+        "remoteIPAddress": "13.226.85.108",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 368,
+        "timing": {
+          "requestTime": 73985.852907,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 1.067,
+          "sendEnd": 1.511,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 1055.393
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "calibreapp.com",
+          "sanList": ["calibreapp.com", "www.calibreapp.com"],
+          "issuer": "Amazon",
+          "validFrom": 1589673600,
+          "validTo": 1623931200,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2021' log",
+              "logId": "F65C942FD1773022145418083094568EE34D131933BFDF0C2F200BCC4EF164E3",
+              "timestamp": 1589682688690,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "3044022033B128B4C6A86EEEB7FE1FB41907AE7F54F30B1BBD5F0B4B47269504682752390220195BDDB26B117410F6B71004982A38C76A4DD7953A89B4D92AEE1020A5EFADEB"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2021 Log",
+              "logId": "5CDC4392FEE6AB4544B15E9AD456E61037FBD5FA47DCA17394B25EE6F6C70ECA",
+              "timestamp": 1589682688713,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "3045022100B3CD451308B0FABCC1255F6F24FC9E01600DF6A2FD43FFBED4DC347B54621B29022056A4FC3E0CC26687B94BA44FDCA751240D5FD1CE29B8581202EC49C52A102538"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.5",
+      "timestamp": 73986.909722,
+      "dataLength": 5802,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.5",
+      "timestamp": 73986.910243,
+      "dataLength": 0,
+      "encodedDataLength": 1752
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "9836.5",
+      "timestamp": 73986.908654,
+      "encodedDataLength": 2120,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.2",
+      "timestamp": 73986.910572,
+      "dataLength": 0,
+      "encodedDataLength": 5921
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "9836.2",
+      "timestamp": 73986.908007,
+      "encodedDataLength": 38689,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "D85D2C04144CFCE566B7A1675D47E268",
+      "loaderId": "",
+      "documentURL": "https://sessions.bugsnag.com/",
+      "request": {
+        "url": "https://sessions.bugsnag.com/",
+        "method": "OPTIONS",
+        "headers": {
+          "Accept": "*/*",
+          "Access-Control-Request-Method": "POST",
+          "Access-Control-Request-Headers": "bugsnag-api-key,bugsnag-payload-version,bugsnag-sent-at,content-type",
+          "Origin": "https://www.calibreapp.com",
+          "Sec-Fetch-Mode": "cors"
+        },
+        "initialPriority": "High",
+        "referrerPolicy": "strict-origin-when-cross-origin"
+      },
+      "timestamp": 73986.918704,
+      "wallTime": 1595909654.404653,
+      "initiator": { "type": "other", "url": "https://sessions.bugsnag.com/" },
+      "type": "Other",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "9836.10",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "documentURL": "https://www.calibreapp.com/sign-in",
+      "request": {
+        "url": "https://sessions.bugsnag.com/",
+        "method": "POST",
+        "headers": {
+          "Bugsnag-Payload-Version": "1",
+          "Referer": "https://www.calibreapp.com/",
+          "Bugsnag-Sent-At": "2020-07-28T04:14:14.403Z",
+          "Bugsnag-Api-Key": "c6fb2ec09c86c86fc2cf8eab520cc389",
+          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+          "Content-Type": "application/json"
+        },
+        "postData": "{\"notifier\":{\"name\":\"Bugsnag JavaScript\",\"version\":\"7.2.1\",\"url\":\"https://github.com/bugsnag/bugsnag-js\"},\"device\":{\"locale\":\"en-GB\",\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36\",\"orientation\":\"landscape-primary\"},\"app\":{\"releaseStage\":\"production\"},\"sessions\":[{\"id\":\"ckd5feide00003h5spki0tcqu\",\"startedAt\":\"2020-07-28T04:14:14.403Z\",\"user\":{}}]}",
+        "hasPostData": true,
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "strict-origin-when-cross-origin"
+      },
+      "timestamp": 73986.91839,
+      "wallTime": 1595909654.404295,
+      "initiator": {
+        "type": "script",
+        "stack": {
+          "callFrames": [
+            {
+              "functionName": "sendSession",
+              "scriptId": "13",
+              "url": "https://d2wy8f7a9ursnm.cloudfront.net/v7/bugsnag.min.js",
+              "lineNumber": 0,
+              "columnNumber": 25970
+            },
+            {
+              "functionName": "startSession",
+              "scriptId": "13",
+              "url": "https://d2wy8f7a9ursnm.cloudfront.net/v7/bugsnag.min.js",
+              "lineNumber": 0,
+              "columnNumber": 26376
+            },
+            {
+              "functionName": "e.startSession",
+              "scriptId": "13",
+              "url": "https://d2wy8f7a9ursnm.cloudfront.net/v7/bugsnag.min.js",
+              "lineNumber": 0,
+              "columnNumber": 18685
+            },
+            {
+              "functionName": "createClient",
+              "scriptId": "13",
+              "url": "https://d2wy8f7a9ursnm.cloudfront.net/v7/bugsnag.min.js",
+              "lineNumber": 0,
+              "columnNumber": 38973
+            },
+            {
+              "functionName": "start",
+              "scriptId": "13",
+              "url": "https://d2wy8f7a9ursnm.cloudfront.net/v7/bugsnag.min.js",
+              "lineNumber": 0,
+              "columnNumber": 39121
+            },
+            {
+              "functionName": "",
+              "scriptId": "14",
+              "url": "https://www.calibreapp.com/sign-in",
+              "lineNumber": 21,
+              "columnNumber": 10
+            }
+          ]
+        }
+      },
+      "type": "XHR",
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "D85D2C04144CFCE566B7A1675D47E268",
+      "associatedCookies": [],
+      "headers": {
+        ":method": "OPTIONS",
+        ":authority": "sessions.bugsnag.com",
+        ":scheme": "https",
+        ":path": "/",
+        "accept": "*/*",
+        "access-control-request-method": "POST",
+        "access-control-request-headers": "bugsnag-api-key,bugsnag-payload-version,bugsnag-sent-at,content-type",
+        "origin": "https://www.calibreapp.com",
+        "sec-fetch-mode": "cors",
+        "sec-fetch-site": "cross-site",
+        "sec-fetch-dest": "empty",
+        "referer": "https://www.calibreapp.com/",
+        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "9836.18",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "documentURL": "https://www.calibreapp.com/sign-in",
+      "request": {
+        "url": "data:image/svg+xml; utf8, <svg width=\"14\" height=\"11\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M1 5.58333L5.00926 10L12.5833 1\" stroke=\"white\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg>",
+        "method": "GET",
+        "headers": {
+          "Referer": "",
+          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 73987.014641,
+      "wallTime": 1595909654.500541,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.calibreapp.com/assets/sign_up_in-8b32538e54b23b40f8fd45c28abdcee2e2d023bd7e01ddf2033d5f781afae9dc.css"
+      },
+      "type": "Image",
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": { "requestId": "9836.18" }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "9836.18",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "timestamp": 73987.014664,
+      "type": "Image",
+      "response": {
+        "url": "data:image/svg+xml; utf8, <svg width=\"14\" height=\"11\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M1 5.58333L5.00926 10L12.5833 1\" stroke=\"white\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg>",
+        "status": 200,
+        "statusText": "OK",
+        "headers": { "Content-Type": "image/svg+xml" },
+        "mimeType": "image/svg+xml",
+        "connectionReused": false,
+        "connectionId": 0,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 0,
+        "protocol": "data",
+        "securityState": "unknown"
+      },
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.18",
+      "timestamp": 73987.014671,
+      "dataLength": 204,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "9836.18",
+      "timestamp": 73987.014676,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "9836.19",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "documentURL": "https://www.calibreapp.com/sign-in",
+      "request": {
+        "url": "data:image/svg+xml; utf8, <svg width=\"14\" height=\"11\" fill=\"none\"%0A    xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M1 5.58333L5.00926 10L12.5833 1\" stroke=\"%233bb079\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg>",
+        "method": "GET",
+        "headers": {
+          "Referer": "",
+          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 73987.015635,
+      "wallTime": 1595909654.501535,
+      "initiator": {
+        "type": "parser",
+        "url": "https://www.calibreapp.com/assets/sign_up_in-8b32538e54b23b40f8fd45c28abdcee2e2d023bd7e01ddf2033d5f781afae9dc.css"
+      },
+      "type": "Image",
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestServedFromCache",
+    "params": { "requestId": "9836.19" }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "9836.19",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "timestamp": 73987.015656,
+      "type": "Image",
+      "response": {
+        "url": "data:image/svg+xml; utf8, <svg width=\"14\" height=\"11\" fill=\"none\"%0A    xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M1 5.58333L5.00926 10L12.5833 1\" stroke=\"%233bb079\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg>",
+        "status": 200,
+        "statusText": "OK",
+        "headers": { "Content-Type": "image/svg+xml" },
+        "mimeType": "image/svg+xml",
+        "connectionReused": false,
+        "connectionId": 0,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 0,
+        "protocol": "data",
+        "securityState": "unknown"
+      },
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.19",
+      "timestamp": 73987.015661,
+      "dataLength": 210,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "9836.19",
+      "timestamp": 73987.015665,
+      "encodedDataLength": 0,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "9836.20",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "documentURL": "https://www.calibreapp.com/sign-in",
+      "request": {
+        "url": "https://widget.intercom.io/widget/pxfscr83",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.calibreapp.com/",
+          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin"
+      },
+      "timestamp": 73987.037667,
+      "wallTime": 1595909654.523566,
+      "initiator": {
+        "type": "script",
+        "stack": {
+          "callFrames": [
+            {
+              "functionName": "l",
+              "scriptId": "16",
+              "url": "https://www.calibreapp.com/sign-in",
+              "lineNumber": 121,
+              "columnNumber": 510
+            },
+            {
+              "functionName": "n.__trace__",
+              "scriptId": "13",
+              "url": "https://d2wy8f7a9ursnm.cloudfront.net/v7/bugsnag.min.js",
+              "lineNumber": 0,
+              "columnNumber": 30156
+            }
+          ],
+          "parent": {
+            "description": "load",
+            "callFrames": [
+              {
+                "functionName": "",
+                "scriptId": "13",
+                "url": "https://d2wy8f7a9ursnm.cloudfront.net/v7/bugsnag.min.js",
+                "lineNumber": 0,
+                "columnNumber": 30284
+              },
+              {
+                "functionName": "",
+                "scriptId": "16",
+                "url": "https://www.calibreapp.com/sign-in",
+                "lineNumber": 121,
+                "columnNumber": 581
+              },
+              {
+                "functionName": "",
+                "scriptId": "16",
+                "url": "https://www.calibreapp.com/sign-in",
+                "lineNumber": 121,
+                "columnNumber": 619
+              }
+            ]
+          }
+        }
+      },
+      "type": "Script",
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "hasUserGesture": false
+    }
+  },
+  { "method": "Page.loadEventFired", "params": { "timestamp": 73987.037849 } },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "name": "load",
+      "timestamp": 73987.037849
+    }
+  },
+  {
+    "method": "Page.frameStoppedLoading",
+    "params": { "frameId": "5356556406F4EF152D876F82DF1B8FFA" }
+  },
+  {
+    "method": "Page.domContentEventFired",
+    "params": { "timestamp": 73987.038264 }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "name": "DOMContentLoaded",
+      "timestamp": 73987.038264
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "9836.21",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "documentURL": "https://www.calibreapp.com/sign-in",
+      "request": {
+        "url": "https://www.calibreapp.com/favicon.ico",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.calibreapp.com/sign-in",
+          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "strict-origin-when-cross-origin"
+      },
+      "timestamp": 73987.041417,
+      "wallTime": 1595909654.527316,
+      "initiator": { "type": "other" },
+      "type": "Other",
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "9836.21",
+      "associatedCookies": [
+        {
+          "blockedReasons": [],
+          "cookie": {
+            "name": "_calibre_app_session",
+            "value": "UlhuZzdnMUxvRjdnMFMxajlFeEFlNDJRQjEwbVlHeEdML3Z1ZDRpMzY0ak1henc1clMwWVdJQXJ0RjVvRnhDR081MlFPTFU2Ulh4RUtPcGZhZ0t0Z3h0OFBmQ1dtM3dvTmJidHZnTTRQZEpIOGNmUVhMRHB4TFcra2VpU21uV3VMN1o2YjhlQmlYRnZ4VDBiUXNHdnBBPT0tLVFjYjdWQXo2SUdIZ0FBOERnblhRaXc9PQ%3D%3D--ebff94e1d82babaca5b55404e2e5da785cd12fb8",
+            "domain": "www.calibreapp.com",
+            "path": "/",
+            "expires": -1,
+            "size": 306,
+            "httpOnly": true,
+            "secure": true,
+            "session": true,
+            "priority": "Medium"
+          }
+        }
+      ],
+      "headers": {
+        ":method": "GET",
+        ":authority": "www.calibreapp.com",
+        ":scheme": "https",
+        ":path": "/favicon.ico",
+        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept": "image/webp,image/apng,image/*,*/*;q=0.8",
+        "sec-fetch-site": "same-origin",
+        "sec-fetch-mode": "no-cors",
+        "sec-fetch-dest": "image",
+        "referer": "https://www.calibreapp.com/sign-in",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
+        "cookie": "_calibre_app_session=UlhuZzdnMUxvRjdnMFMxajlFeEFlNDJRQjEwbVlHeEdML3Z1ZDRpMzY0ak1henc1clMwWVdJQXJ0RjVvRnhDR081MlFPTFU2Ulh4RUtPcGZhZ0t0Z3h0OFBmQ1dtM3dvTmJidHZnTTRQZEpIOGNmUVhMRHB4TFcra2VpU21uV3VMN1o2YjhlQmlYRnZ4VDBiUXNHdnBBPT0tLVFjYjdWQXo2SUdIZ0FBOERnblhRaXc9PQ%3D%3D--ebff94e1d82babaca5b55404e2e5da785cd12fb8"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "9836.21",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "content-type": "image/vnd.microsoft.icon",
+        "content-length": "1700",
+        "server": "Cowboy",
+        "date": "Sat, 25 Jul 2020 22:24:41 GMT",
+        "last-modified": "Fri, 24 Jul 2020 04:13:37 GMT",
+        "cache-control": "public, s-maxage=31536000, maxage=15552000, no-transform",
+        "expires": "Sun, 25 Jul 2021 06:27:13 +0000",
+        "access-control-allow-origin": "*",
+        "strict-transport-security": "max-age=31536000; includeSubDomains",
+        "via": "1.1 vegur, 1.1 c9b90fe1dcd0958f352b5816fbce3bbe.cloudfront.net (CloudFront)",
+        "x-cache": "Hit from cloudfront",
+        "x-amz-cf-pop": "SYD4-C2",
+        "x-amz-cf-id": "wnrST5_OtHxwAHhmM9PTQp92gKqYd-SVVKYMKc_ieOgsTdr8rp4l3A==",
+        "age": "193772"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "9836.21",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "timestamp": 73987.051816,
+      "type": "Other",
+      "response": {
+        "url": "https://www.calibreapp.com/favicon.ico",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Sat, 25 Jul 2020 22:24:41 GMT",
+          "via": "1.1 vegur, 1.1 c9b90fe1dcd0958f352b5816fbce3bbe.cloudfront.net (CloudFront)",
+          "last-modified": "Fri, 24 Jul 2020 04:13:37 GMT",
+          "server": "Cowboy",
+          "age": "193772",
+          "status": "200",
+          "strict-transport-security": "max-age=31536000; includeSubDomains",
+          "x-cache": "Hit from cloudfront",
+          "content-type": "image/vnd.microsoft.icon",
+          "access-control-allow-origin": "*",
+          "cache-control": "public, s-maxage=31536000, maxage=15552000, no-transform",
+          "x-amz-cf-pop": "SYD4-C2",
+          "content-length": "1700",
+          "x-amz-cf-id": "wnrST5_OtHxwAHhmM9PTQp92gKqYd-SVVKYMKc_ieOgsTdr8rp4l3A==",
+          "expires": "Sun, 25 Jul 2021 06:27:13 +0000"
+        },
+        "mimeType": "image/vnd.microsoft.icon",
+        "connectionReused": true,
+        "connectionId": 38,
+        "remoteIPAddress": "13.226.85.108",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 432,
+        "timing": {
+          "requestTime": 73987.04168,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 0.188,
+          "sendEnd": 0.296,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 9.379
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "calibreapp.com",
+          "sanList": ["calibreapp.com", "www.calibreapp.com"],
+          "issuer": "Amazon",
+          "validFrom": 1589673600,
+          "validTo": 1623931200,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2021' log",
+              "logId": "F65C942FD1773022145418083094568EE34D131933BFDF0C2F200BCC4EF164E3",
+              "timestamp": 1589682688690,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "3044022033B128B4C6A86EEEB7FE1FB41907AE7F54F30B1BBD5F0B4B47269504682752390220195BDDB26B117410F6B71004982A38C76A4DD7953A89B4D92AEE1020A5EFADEB"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2021 Log",
+              "logId": "5CDC4392FEE6AB4544B15E9AD456E61037FBD5FA47DCA17394B25EE6F6C70ECA",
+              "timestamp": 1589682688713,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "3045022100B3CD451308B0FABCC1255F6F24FC9E01600DF6A2FD43FFBED4DC347B54621B29022056A4FC3E0CC26687B94BA44FDCA751240D5FD1CE29B8581202EC49C52A102538"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.21",
+      "timestamp": 73987.051911,
+      "dataLength": 1700,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.21",
+      "timestamp": 73987.053382,
+      "dataLength": 0,
+      "encodedDataLength": 1709
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "9836.21",
+      "timestamp": 73987.051292,
+      "encodedDataLength": 2141,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "9836.20",
+      "associatedCookies": [],
+      "headers": {
+        ":method": "GET",
+        ":authority": "widget.intercom.io",
+        ":scheme": "https",
+        ":path": "/widget/pxfscr83",
+        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept": "*/*",
+        "sec-fetch-site": "cross-site",
+        "sec-fetch-mode": "no-cors",
+        "sec-fetch-dest": "script",
+        "referer": "https://www.calibreapp.com/",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "9836.20",
+      "blockedCookies": [],
+      "headers": {
+        "status": "302",
+        "content-length": "0",
+        "location": "https://js.intercomcdn.com/shim.latest.js",
+        "date": "Thu, 25 Jun 2020 00:02:01 GMT",
+        "server": "AmazonS3",
+        "x-cache": "Hit from cloudfront",
+        "via": "1.1 360bc380530e42ff8d4114ee99dd6212.cloudfront.net (CloudFront)",
+        "x-amz-cf-pop": "SYD4-C1",
+        "x-amz-cf-id": "d3lKRxGwT7FK5tstcXGRYkBZEST5eV3vlZusgY1pPBaFo8puZx-rRQ==",
+        "age": "2866333"
+      }
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "9836.20",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "documentURL": "https://www.calibreapp.com/sign-in",
+      "request": {
+        "url": "https://js.intercomcdn.com/shim.latest.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "https://www.calibreapp.com/",
+          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "strict-origin-when-cross-origin"
+      },
+      "timestamp": 73987.125516,
+      "wallTime": 1595909654.611412,
+      "initiator": { "type": "other" },
+      "redirectResponse": {
+        "url": "https://widget.intercom.io/widget/pxfscr83",
+        "status": 302,
+        "statusText": "",
+        "headers": {
+          "date": "Thu, 25 Jun 2020 00:02:01 GMT",
+          "via": "1.1 360bc380530e42ff8d4114ee99dd6212.cloudfront.net (CloudFront)",
+          "server": "AmazonS3",
+          "age": "2866333",
+          "status": "302",
+          "x-cache": "Hit from cloudfront",
+          "location": "https://js.intercomcdn.com/shim.latest.js",
+          "x-amz-cf-pop": "SYD4-C1",
+          "content-length": "0",
+          "x-amz-cf-id": "d3lKRxGwT7FK5tstcXGRYkBZEST5eV3vlZusgY1pPBaFo8puZx-rRQ=="
+        },
+        "mimeType": "",
+        "connectionReused": false,
+        "connectionId": 105,
+        "remoteIPAddress": "99.86.212.45",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 251,
+        "timing": {
+          "requestTime": 73987.037957,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.134,
+          "dnsEnd": 32.248,
+          "connectStart": 32.248,
+          "connectEnd": 72.432,
+          "sslStart": 45.072,
+          "sslEnd": 72.427,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 72.556,
+          "sendEnd": 72.652,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 86.916
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "*.intercom.com",
+          "sanList": [
+            "*.intercom.com",
+            "intercom.io",
+            "intercom.com",
+            "*.intercom.io"
+          ],
+          "issuer": "Amazon",
+          "validFrom": 1589328000,
+          "validTo": 1623585600,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2021' log",
+              "logId": "F65C942FD1773022145418083094568EE34D131933BFDF0C2F200BCC4EF164E3",
+              "timestamp": 1589336958723,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "3046022100A8C88BFEAB35BEA916C11D94394084A4460897C15966AF750396D38CFBC3A9DC0221009D07DE694AD9510723E09ACD6120CA89CFBE6BFF0AEF2CE4C6026B11CBDADACB"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2021 Log",
+              "logId": "5CDC4392FEE6AB4544B15E9AD456E61037FBD5FA47DCA17394B25EE6F6C70ECA",
+              "timestamp": 1589336958753,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "304402207BDDD83FBC10CFEF5790A75E2640DC1EF0464779DEF61F28D8832ABE8C559C40022068ACE99088175BE65D2EF63BC08A69909334468B923152893C38425E2910168D"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "type": "Script",
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "name": "firstPaint",
+      "timestamp": 73987.144202
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "name": "firstContentfulPaint",
+      "timestamp": 73987.144202
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "name": "firstImagePaint",
+      "timestamp": 73987.144202
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "D85D2C04144CFCE566B7A1675D47E268",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "access-control-allow-headers": "Origin, Content-Type, Accept, Authorization, User-Agent, Referer, X-Forwarded-For, Bugsnag-Api-Key, Bugsnag-Payload-Version, Bugsnag-Sent-At",
+        "access-control-allow-methods": "POST",
+        "access-control-allow-origin": "*",
+        "date": "Tue, 28 Jul 2020 04:14:14 GMT",
+        "content-length": "0",
+        "via": "1.1 google",
+        "alt-svc": "clear"
+      }
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "name": "firstMeaningfulPaintCandidate",
+      "timestamp": 73987.144202
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "D85D2C04144CFCE566B7A1675D47E268",
+      "loaderId": "",
+      "timestamp": 73987.147751,
+      "type": "Other",
+      "response": {
+        "url": "https://sessions.bugsnag.com/",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "status": "200",
+          "access-control-allow-headers": "Origin, Content-Type, Accept, Authorization, User-Agent, Referer, X-Forwarded-For, Bugsnag-Api-Key, Bugsnag-Payload-Version, Bugsnag-Sent-At",
+          "access-control-allow-methods": "POST",
+          "access-control-allow-origin": "*",
+          "date": "Tue, 28 Jul 2020 04:14:14 GMT",
+          "content-length": "0",
+          "via": "1.1 google",
+          "alt-svc": "clear"
+        },
+        "mimeType": "",
+        "connectionReused": false,
+        "connectionId": 82,
+        "remoteIPAddress": "35.190.88.7",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 219,
+        "timing": {
+          "requestTime": 73986.918741,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.068,
+          "dnsEnd": 18.709,
+          "connectStart": 18.709,
+          "connectEnd": 53.426,
+          "sslStart": 31.68,
+          "sslEnd": 53.421,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 53.521,
+          "sendEnd": 53.62,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 226.53
+        },
+        "protocol": "h2",
+        "securityState": "secure"
+      }
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "D85D2C04144CFCE566B7A1675D47E268",
+      "timestamp": 73987.145639,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "9836.10",
+      "associatedCookies": [],
+      "headers": {
+        ":method": "POST",
+        ":authority": "sessions.bugsnag.com",
+        ":scheme": "https",
+        ":path": "/",
+        "content-length": "437",
+        "bugsnag-payload-version": "1",
+        "bugsnag-sent-at": "2020-07-28T04:14:14.403Z",
+        "bugsnag-api-key": "c6fb2ec09c86c86fc2cf8eab520cc389",
+        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "content-type": "application/json",
+        "accept": "*/*",
+        "origin": "https://www.calibreapp.com",
+        "sec-fetch-site": "cross-site",
+        "sec-fetch-mode": "cors",
+        "sec-fetch-dest": "empty",
+        "referer": "https://www.calibreapp.com/",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "9836.20",
+      "associatedCookies": [],
+      "headers": {
+        ":method": "GET",
+        ":authority": "js.intercomcdn.com",
+        ":scheme": "https",
+        ":path": "/shim.latest.js",
+        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept": "*/*",
+        "sec-fetch-site": "cross-site",
+        "sec-fetch-mode": "no-cors",
+        "sec-fetch-dest": "script",
+        "referer": "https://www.calibreapp.com/",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "9836.20",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "content-type": "application/javascript; charset=UTF-8",
+        "content-length": "2908",
+        "last-modified": "Thu, 23 Jul 2020 08:33:52 GMT",
+        "x-amz-server-side-encryption": "AES256",
+        "content-encoding": "gzip",
+        "accept-ranges": "bytes",
+        "server": "AmazonS3",
+        "date": "Tue, 28 Jul 2020 04:13:11 GMT",
+        "etag": "\"f5fc9ca2c621d782230d1af185fd7b1a\"",
+        "cache-control": "max-age=300, s-maxage=300, public",
+        "x-cache": "Hit from cloudfront",
+        "via": "1.1 6aa566da4fde43dfaa62af1eee8e24e9.cloudfront.net (CloudFront)",
+        "x-amz-cf-pop": "SYD4-C1",
+        "x-amz-cf-id": "NDnvGaqgpjoip_98No_I6IypxJUafYv4c-7XvyoOOPAVACT03pWrSQ==",
+        "age": "64"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "9836.20",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "timestamp": 73987.190363,
+      "type": "Script",
+      "response": {
+        "url": "https://js.intercomcdn.com/shim.latest.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Tue, 28 Jul 2020 04:13:11 GMT",
+          "content-encoding": "gzip",
+          "age": "64",
+          "x-amz-server-side-encryption": "AES256",
+          "x-cache": "Hit from cloudfront",
+          "status": "200",
+          "content-length": "2908",
+          "last-modified": "Thu, 23 Jul 2020 08:33:52 GMT",
+          "server": "AmazonS3",
+          "etag": "\"f5fc9ca2c621d782230d1af185fd7b1a\"",
+          "content-type": "application/javascript; charset=UTF-8",
+          "via": "1.1 6aa566da4fde43dfaa62af1eee8e24e9.cloudfront.net (CloudFront)",
+          "cache-control": "max-age=300, s-maxage=300, public",
+          "x-amz-cf-pop": "SYD4-C1",
+          "accept-ranges": "bytes",
+          "x-amz-cf-id": "NDnvGaqgpjoip_98No_I6IypxJUafYv4c-7XvyoOOPAVACT03pWrSQ=="
+        },
+        "mimeType": "application/javascript",
+        "connectionReused": false,
+        "connectionId": 118,
+        "remoteIPAddress": "99.86.212.57",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 405,
+        "timing": {
+          "requestTime": 73987.125659,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.13,
+          "dnsEnd": 20.688,
+          "connectStart": 20.688,
+          "connectEnd": 50.796,
+          "sslStart": 32.609,
+          "sslEnd": 50.791,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 50.967,
+          "sendEnd": 51.043,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 63.163
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "*.intercomcdn.com",
+          "sanList": ["*.intercomcdn.com"],
+          "issuer": "Amazon",
+          "validFrom": 1585440000,
+          "validTo": 1619697600,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2021' log",
+              "logId": "F65C942FD1773022145418083094568EE34D131933BFDF0C2F200BCC4EF164E3",
+              "timestamp": 1585449692977,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "304502204FFB1F509EFBCF26D672D52576D03FBE62CE9B8C913F843EE12740FDB7D0AFA2022100861B92D9EC9182B36DABB8A5586520EF9E526FCDF4787B5D8C8EB04B63FCC56B"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2021 Log",
+              "logId": "5CDC4392FEE6AB4544B15E9AD456E61037FBD5FA47DCA17394B25EE6F6C70ECA",
+              "timestamp": 1585449693060,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "3045022100D378A099A13B3E9AD2C78B71E4D887F983F8F9734D3C3600FB957C26B295497302200C19DC1737AA6EBBCB2BF06771C10761DD817E69B2FC60B4862A507602CBDB23"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.20",
+      "timestamp": 73987.190476,
+      "dataLength": 7483,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "9836.20",
+      "timestamp": 73987.189274,
+      "encodedDataLength": 3322,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Page.frameAttached",
+    "params": {
+      "frameId": "39F0C427EB9AB69251CD913A11701846",
+      "parentFrameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "stack": {
+        "callFrames": [
+          {
+            "functionName": "h",
+            "scriptId": "17",
+            "url": "https://widget.intercom.io/widget/pxfscr83",
+            "lineNumber": 0,
+            "columnNumber": 6217
+          },
+          {
+            "functionName": "g",
+            "scriptId": "17",
+            "url": "https://widget.intercom.io/widget/pxfscr83",
+            "lineNumber": 0,
+            "columnNumber": 6824
+          },
+          {
+            "functionName": "945",
+            "scriptId": "17",
+            "url": "https://widget.intercom.io/widget/pxfscr83",
+            "lineNumber": 0,
+            "columnNumber": 7206
+          },
+          {
+            "functionName": "n",
+            "scriptId": "17",
+            "url": "https://widget.intercom.io/widget/pxfscr83",
+            "lineNumber": 0,
+            "columnNumber": 109
+          },
+          {
+            "functionName": "920",
+            "scriptId": "17",
+            "url": "https://widget.intercom.io/widget/pxfscr83",
+            "lineNumber": 0,
+            "columnNumber": 5060
+          },
+          {
+            "functionName": "n",
+            "scriptId": "17",
+            "url": "https://widget.intercom.io/widget/pxfscr83",
+            "lineNumber": 0,
+            "columnNumber": 109
+          },
+          {
+            "functionName": "",
+            "scriptId": "17",
+            "url": "https://widget.intercom.io/widget/pxfscr83",
+            "lineNumber": 0,
+            "columnNumber": 928
+          },
+          {
+            "functionName": "",
+            "scriptId": "17",
+            "url": "https://widget.intercom.io/widget/pxfscr83",
+            "lineNumber": 0,
+            "columnNumber": 939
+          }
+        ]
+      }
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "39F0C427EB9AB69251CD913A11701846",
+      "loaderId": "ECB270659C5E34DDA85E52827B7E3A9A",
+      "name": "init",
+      "timestamp": 73987.193153
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "39F0C427EB9AB69251CD913A11701846",
+      "loaderId": "ECB270659C5E34DDA85E52827B7E3A9A",
+      "name": "DOMContentLoaded",
+      "timestamp": 73987.193588
+    }
+  },
+  {
+    "method": "Page.frameStartedLoading",
+    "params": { "frameId": "39F0C427EB9AB69251CD913A11701846" }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "39F0C427EB9AB69251CD913A11701846",
+      "loaderId": "557CE884022B6FE686E45ABB1038FDF3",
+      "name": "init",
+      "timestamp": 73987.194136
+    }
+  },
+  {
+    "method": "Page.frameNavigated",
+    "params": {
+      "frame": {
+        "id": "39F0C427EB9AB69251CD913A11701846",
+        "parentId": "5356556406F4EF152D876F82DF1B8FFA",
+        "loaderId": "557CE884022B6FE686E45ABB1038FDF3",
+        "name": "intercom-frame",
+        "url": "about:blank",
+        "securityOrigin": "://",
+        "mimeType": "text/html"
+      }
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "39F0C427EB9AB69251CD913A11701846",
+      "loaderId": "557CE884022B6FE686E45ABB1038FDF3",
+      "name": "load",
+      "timestamp": 73987.197521
+    }
+  },
+  {
+    "method": "Page.frameStoppedLoading",
+    "params": { "frameId": "39F0C427EB9AB69251CD913A11701846" }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "39F0C427EB9AB69251CD913A11701846",
+      "loaderId": "557CE884022B6FE686E45ABB1038FDF3",
+      "name": "DOMContentLoaded",
+      "timestamp": 73987.197765
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "9836.22",
+      "associatedCookies": [],
+      "headers": {
+        ":method": "GET",
+        ":authority": "js.intercomcdn.com",
+        ":scheme": "https",
+        ":path": "/frame-modern.7ede733e.js",
+        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept": "*/*",
+        "sec-fetch-site": "cross-site",
+        "sec-fetch-mode": "no-cors",
+        "sec-fetch-dest": "script",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "9836.22",
+      "loaderId": "557CE884022B6FE686E45ABB1038FDF3",
+      "documentURL": "about:blank",
+      "request": {
+        "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "",
+          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 73987.198538,
+      "wallTime": 1595909654.68443,
+      "initiator": {
+        "type": "script",
+        "stack": {
+          "callFrames": [
+            {
+              "functionName": "h",
+              "scriptId": "17",
+              "url": "https://widget.intercom.io/widget/pxfscr83",
+              "lineNumber": 0,
+              "columnNumber": 6473
+            },
+            {
+              "functionName": "g",
+              "scriptId": "17",
+              "url": "https://widget.intercom.io/widget/pxfscr83",
+              "lineNumber": 0,
+              "columnNumber": 6824
+            },
+            {
+              "functionName": "945",
+              "scriptId": "17",
+              "url": "https://widget.intercom.io/widget/pxfscr83",
+              "lineNumber": 0,
+              "columnNumber": 7206
+            },
+            {
+              "functionName": "n",
+              "scriptId": "17",
+              "url": "https://widget.intercom.io/widget/pxfscr83",
+              "lineNumber": 0,
+              "columnNumber": 109
+            },
+            {
+              "functionName": "920",
+              "scriptId": "17",
+              "url": "https://widget.intercom.io/widget/pxfscr83",
+              "lineNumber": 0,
+              "columnNumber": 5060
+            },
+            {
+              "functionName": "n",
+              "scriptId": "17",
+              "url": "https://widget.intercom.io/widget/pxfscr83",
+              "lineNumber": 0,
+              "columnNumber": 109
+            },
+            {
+              "functionName": "",
+              "scriptId": "17",
+              "url": "https://widget.intercom.io/widget/pxfscr83",
+              "lineNumber": 0,
+              "columnNumber": 928
+            },
+            {
+              "functionName": "",
+              "scriptId": "17",
+              "url": "https://widget.intercom.io/widget/pxfscr83",
+              "lineNumber": 0,
+              "columnNumber": 939
+            }
+          ]
+        }
+      },
+      "type": "Script",
+      "frameId": "39F0C427EB9AB69251CD913A11701846",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "9836.23",
+      "loaderId": "557CE884022B6FE686E45ABB1038FDF3",
+      "documentURL": "about:blank",
+      "request": {
+        "url": "https://js.intercomcdn.com/vendor-modern.6f14031b.js",
+        "method": "GET",
+        "headers": {
+          "Referer": "",
+          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
+        },
+        "mixedContentType": "none",
+        "initialPriority": "Low",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 73987.198929,
+      "wallTime": 1595909654.684821,
+      "initiator": {
+        "type": "script",
+        "stack": {
+          "callFrames": [
+            {
+              "functionName": "h",
+              "scriptId": "17",
+              "url": "https://widget.intercom.io/widget/pxfscr83",
+              "lineNumber": 0,
+              "columnNumber": 6511
+            },
+            {
+              "functionName": "g",
+              "scriptId": "17",
+              "url": "https://widget.intercom.io/widget/pxfscr83",
+              "lineNumber": 0,
+              "columnNumber": 6824
+            },
+            {
+              "functionName": "945",
+              "scriptId": "17",
+              "url": "https://widget.intercom.io/widget/pxfscr83",
+              "lineNumber": 0,
+              "columnNumber": 7206
+            },
+            {
+              "functionName": "n",
+              "scriptId": "17",
+              "url": "https://widget.intercom.io/widget/pxfscr83",
+              "lineNumber": 0,
+              "columnNumber": 109
+            },
+            {
+              "functionName": "920",
+              "scriptId": "17",
+              "url": "https://widget.intercom.io/widget/pxfscr83",
+              "lineNumber": 0,
+              "columnNumber": 5060
+            },
+            {
+              "functionName": "n",
+              "scriptId": "17",
+              "url": "https://widget.intercom.io/widget/pxfscr83",
+              "lineNumber": 0,
+              "columnNumber": 109
+            },
+            {
+              "functionName": "",
+              "scriptId": "17",
+              "url": "https://widget.intercom.io/widget/pxfscr83",
+              "lineNumber": 0,
+              "columnNumber": 928
+            },
+            {
+              "functionName": "",
+              "scriptId": "17",
+              "url": "https://widget.intercom.io/widget/pxfscr83",
+              "lineNumber": 0,
+              "columnNumber": 939
+            }
+          ]
+        }
+      },
+      "type": "Script",
+      "frameId": "39F0C427EB9AB69251CD913A11701846",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "9836.23",
+      "associatedCookies": [],
+      "headers": {
+        ":method": "GET",
+        ":authority": "js.intercomcdn.com",
+        ":scheme": "https",
+        ":path": "/vendor-modern.6f14031b.js",
+        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "accept": "*/*",
+        "sec-fetch-site": "cross-site",
+        "sec-fetch-mode": "no-cors",
+        "sec-fetch-dest": "script",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "9836.22",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "content-type": "application/javascript; charset=UTF-8",
+        "content-length": "63306",
+        "last-modified": "Thu, 23 Jul 2020 08:25:47 GMT",
+        "x-amz-server-side-encryption": "AES256",
+        "content-encoding": "gzip",
+        "accept-ranges": "bytes",
+        "server": "AmazonS3",
+        "date": "Tue, 28 Jul 2020 03:23:09 GMT",
+        "etag": "\"f15380fc49fcb67d91b0bfc5e94efc00\"",
+        "cache-control": "max-age=31536000, s-maxage=7200, public",
+        "x-cache": "Hit from cloudfront",
+        "via": "1.1 6aa566da4fde43dfaa62af1eee8e24e9.cloudfront.net (CloudFront)",
+        "x-amz-cf-pop": "SYD4-C1",
+        "x-amz-cf-id": "jW0A4XHbgtxUCKrk8wI_nnDL01nLf-pncN_T_nwQP1w42Q2FrENmjA==",
+        "age": "3065"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "9836.23",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200",
+        "content-type": "application/javascript; charset=UTF-8",
+        "content-length": "52304",
+        "last-modified": "Fri, 17 Jul 2020 15:55:43 GMT",
+        "x-amz-server-side-encryption": "AES256",
+        "content-encoding": "gzip",
+        "accept-ranges": "bytes",
+        "server": "AmazonS3",
+        "date": "Tue, 28 Jul 2020 03:23:12 GMT",
+        "etag": "\"36d04e3742dbd5e4735693d6d89bc469\"",
+        "cache-control": "max-age=31536000, s-maxage=7200, public",
+        "x-cache": "Hit from cloudfront",
+        "via": "1.1 6aa566da4fde43dfaa62af1eee8e24e9.cloudfront.net (CloudFront)",
+        "x-amz-cf-pop": "SYD4-C1",
+        "x-amz-cf-id": "E2xbWfhPFapZdqnfqC9IAcvvC4KUtR1bWtXyBXSpSX9WRrQVREtypQ==",
+        "age": "3063"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "9836.22",
+      "loaderId": "557CE884022B6FE686E45ABB1038FDF3",
+      "timestamp": 73987.216271,
+      "type": "Script",
+      "response": {
+        "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Tue, 28 Jul 2020 03:23:09 GMT",
+          "content-encoding": "gzip",
+          "age": "3065",
+          "x-amz-server-side-encryption": "AES256",
+          "x-cache": "Hit from cloudfront",
+          "status": "200",
+          "content-length": "63306",
+          "last-modified": "Thu, 23 Jul 2020 08:25:47 GMT",
+          "server": "AmazonS3",
+          "etag": "\"f15380fc49fcb67d91b0bfc5e94efc00\"",
+          "content-type": "application/javascript; charset=UTF-8",
+          "via": "1.1 6aa566da4fde43dfaa62af1eee8e24e9.cloudfront.net (CloudFront)",
+          "cache-control": "max-age=31536000, s-maxage=7200, public",
+          "x-amz-cf-pop": "SYD4-C1",
+          "accept-ranges": "bytes",
+          "x-amz-cf-id": "jW0A4XHbgtxUCKrk8wI_nnDL01nLf-pncN_T_nwQP1w42Q2FrENmjA=="
+        },
+        "mimeType": "application/javascript",
+        "connectionReused": true,
+        "connectionId": 118,
+        "remoteIPAddress": "99.86.212.57",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 411,
+        "timing": {
+          "requestTime": 73987.198903,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 0.143,
+          "sendEnd": 0.479,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 13.751
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "*.intercomcdn.com",
+          "sanList": ["*.intercomcdn.com"],
+          "issuer": "Amazon",
+          "validFrom": 1585440000,
+          "validTo": 1619697600,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2021' log",
+              "logId": "F65C942FD1773022145418083094568EE34D131933BFDF0C2F200BCC4EF164E3",
+              "timestamp": 1585449692977,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "304502204FFB1F509EFBCF26D672D52576D03FBE62CE9B8C913F843EE12740FDB7D0AFA2022100861B92D9EC9182B36DABB8A5586520EF9E526FCDF4787B5D8C8EB04B63FCC56B"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2021 Log",
+              "logId": "5CDC4392FEE6AB4544B15E9AD456E61037FBD5FA47DCA17394B25EE6F6C70ECA",
+              "timestamp": 1585449693060,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "3045022100D378A099A13B3E9AD2C78B71E4D887F983F8F9734D3C3600FB957C26B295497302200C19DC1737AA6EBBCB2BF06771C10761DD817E69B2FC60B4862A507602CBDB23"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "39F0C427EB9AB69251CD913A11701846"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.22",
+      "timestamp": 73987.216482,
+      "dataLength": 47631,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.22",
+      "timestamp": 73987.220049,
+      "dataLength": 62939,
+      "encodedDataLength": 31944
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.22",
+      "timestamp": 73987.223862,
+      "dataLength": 68857,
+      "encodedDataLength": 16384
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.22",
+      "timestamp": 73987.226454,
+      "dataLength": 49892,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.22",
+      "timestamp": 73987.227687,
+      "dataLength": 0,
+      "encodedDataLength": 15050
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "9836.22",
+      "timestamp": 73987.226159,
+      "encodedDataLength": 63789,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "9836.23",
+      "loaderId": "557CE884022B6FE686E45ABB1038FDF3",
+      "timestamp": 73987.23237,
+      "type": "Script",
+      "response": {
+        "url": "https://js.intercomcdn.com/vendor-modern.6f14031b.js",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Tue, 28 Jul 2020 03:23:12 GMT",
+          "content-encoding": "gzip",
+          "age": "3063",
+          "x-amz-server-side-encryption": "AES256",
+          "x-cache": "Hit from cloudfront",
+          "status": "200",
+          "content-length": "52304",
+          "last-modified": "Fri, 17 Jul 2020 15:55:43 GMT",
+          "server": "AmazonS3",
+          "etag": "\"36d04e3742dbd5e4735693d6d89bc469\"",
+          "content-type": "application/javascript; charset=UTF-8",
+          "via": "1.1 6aa566da4fde43dfaa62af1eee8e24e9.cloudfront.net (CloudFront)",
+          "cache-control": "max-age=31536000, s-maxage=7200, public",
+          "x-amz-cf-pop": "SYD4-C1",
+          "accept-ranges": "bytes",
+          "x-amz-cf-id": "E2xbWfhPFapZdqnfqC9IAcvvC4KUtR1bWtXyBXSpSX9WRrQVREtypQ=="
+        },
+        "mimeType": "application/javascript",
+        "connectionReused": true,
+        "connectionId": 118,
+        "remoteIPAddress": "99.86.212.57",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 413,
+        "timing": {
+          "requestTime": 73987.199189,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 0.217,
+          "sendEnd": 0.289,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 13.911
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "*.intercomcdn.com",
+          "sanList": ["*.intercomcdn.com"],
+          "issuer": "Amazon",
+          "validFrom": 1585440000,
+          "validTo": 1619697600,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2021' log",
+              "logId": "F65C942FD1773022145418083094568EE34D131933BFDF0C2F200BCC4EF164E3",
+              "timestamp": 1585449692977,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "304502204FFB1F509EFBCF26D672D52576D03FBE62CE9B8C913F843EE12740FDB7D0AFA2022100861B92D9EC9182B36DABB8A5586520EF9E526FCDF4787B5D8C8EB04B63FCC56B"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2021 Log",
+              "logId": "5CDC4392FEE6AB4544B15E9AD456E61037FBD5FA47DCA17394B25EE6F6C70ECA",
+              "timestamp": 1585449693060,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "3045022100D378A099A13B3E9AD2C78B71E4D887F983F8F9734D3C3600FB957C26B295497302200C19DC1737AA6EBBCB2BF06771C10761DD817E69B2FC60B4862A507602CBDB23"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "39F0C427EB9AB69251CD913A11701846"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.23",
+      "timestamp": 73987.232455,
+      "dataLength": 50179,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.23",
+      "timestamp": 73987.235024,
+      "dataLength": 65536,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.23",
+      "timestamp": 73987.235885,
+      "dataLength": 60010,
+      "encodedDataLength": 52367
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "9836.23",
+      "timestamp": 73987.235216,
+      "encodedDataLength": 52780,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSent",
+    "params": {
+      "requestId": "9836.24",
+      "loaderId": "557CE884022B6FE686E45ABB1038FDF3",
+      "documentURL": "about:blank",
+      "request": {
+        "url": "https://api-iam.intercom.io/messenger/web/ping",
+        "method": "POST",
+        "headers": {
+          "Referer": "",
+          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+          "Content-Type": "application/x-www-form-urlencoded"
+        },
+        "postData": "app_id=pxfscr83&v=3&g=14416b9accf5780b2a57ccb90108ee6a051fc063&s=ba24a464-fb41-40ec-a6e0-28138424313f&i=&r=&platform=web&Idempotency-Key=4574f21ab2ec7abd&user_data=%7B%7D&internal=%7B%7D&page_title=Calibre%20%E2%80%94%20Login%20to%20Calibre&user_active_company_id=undefined&source=apiBoot&sampling=false&h=false&referer=https%3A%2F%2Fwww.calibreapp.com%2Fsign-in",
+        "hasPostData": true,
+        "mixedContentType": "none",
+        "initialPriority": "High",
+        "referrerPolicy": "no-referrer-when-downgrade"
+      },
+      "timestamp": 73987.275447,
+      "wallTime": 1595909654.761335,
+      "initiator": {
+        "type": "script",
+        "stack": {
+          "callFrames": [
+            {
+              "functionName": "i",
+              "scriptId": "21",
+              "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+              "lineNumber": 0,
+              "columnNumber": 73619
+            },
+            {
+              "functionName": "",
+              "scriptId": "21",
+              "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+              "lineNumber": 0,
+              "columnNumber": 73758
+            },
+            {
+              "functionName": "o",
+              "scriptId": "21",
+              "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+              "lineNumber": 0,
+              "columnNumber": 73672
+            },
+            {
+              "functionName": "post",
+              "scriptId": "21",
+              "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+              "lineNumber": 0,
+              "columnNumber": 75722
+            },
+            {
+              "functionName": "createOrUpdateUser",
+              "scriptId": "21",
+              "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+              "lineNumber": 0,
+              "columnNumber": 47256
+            },
+            {
+              "functionName": "",
+              "scriptId": "21",
+              "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+              "lineNumber": 0,
+              "columnNumber": 206614
+            },
+            {
+              "functionName": "",
+              "scriptId": "21",
+              "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+              "lineNumber": 0,
+              "columnNumber": 201955
+            },
+            {
+              "functionName": "r",
+              "scriptId": "21",
+              "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+              "lineNumber": 0,
+              "columnNumber": 201812
+            }
+          ],
+          "parent": {
+            "description": "Promise.then",
+            "callFrames": [
+              {
+                "functionName": "",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 201848
+              },
+              {
+                "functionName": "",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 203956
+              },
+              {
+                "functionName": "",
+                "scriptId": "22",
+                "url": "https://js.intercomcdn.com/vendor-modern.6f14031b.js",
+                "lineNumber": 0,
+                "columnNumber": 64612
+              },
+              {
+                "functionName": "createOrUpdateUser",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 163749
+              },
+              {
+                "functionName": "createOrUpdateUser",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 178275
+              },
+              {
+                "functionName": "boot",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 180245
+              },
+              {
+                "functionName": "",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 181347
+              },
+              {
+                "functionName": "393",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 182518
+              },
+              {
+                "functionName": "o",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 560
+              },
+              {
+                "functionName": "230",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 64316
+              },
+              {
+                "functionName": "o",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 560
+              },
+              {
+                "functionName": "229",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 64090
+              },
+              {
+                "functionName": "o",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 560
+              },
+              {
+                "functionName": "n",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 429
+              },
+              {
+                "functionName": "t",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 292
+              },
+              {
+                "functionName": "",
+                "scriptId": "22",
+                "url": "https://js.intercomcdn.com/vendor-modern.6f14031b.js",
+                "lineNumber": 0,
+                "columnNumber": 46
+              }
+            ]
+          }
+        }
+      },
+      "type": "XHR",
+      "frameId": "39F0C427EB9AB69251CD913A11701846",
+      "hasUserGesture": false
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "9836.10",
+      "blockedCookies": [],
+      "headers": {
+        "status": "202",
+        "access-control-allow-origin": "*",
+        "content-type": "application/json",
+        "date": "Tue, 28 Jul 2020 04:14:14 GMT",
+        "content-length": "21",
+        "via": "1.1 google",
+        "alt-svc": "clear"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "9836.10",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "timestamp": 73987.326804,
+      "type": "XHR",
+      "response": {
+        "url": "https://sessions.bugsnag.com/",
+        "status": 202,
+        "statusText": "",
+        "headers": {
+          "status": "202",
+          "date": "Tue, 28 Jul 2020 04:14:14 GMT",
+          "via": "1.1 google",
+          "access-control-allow-origin": "*",
+          "alt-svc": "clear",
+          "content-length": "21",
+          "content-type": "application/json"
+        },
+        "mimeType": "application/json",
+        "connectionReused": true,
+        "connectionId": 82,
+        "remoteIPAddress": "35.190.88.7",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 58,
+        "timing": {
+          "requestTime": 73987.145869,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": -1,
+          "dnsEnd": -1,
+          "connectStart": -1,
+          "connectEnd": -1,
+          "sslStart": -1,
+          "sslEnd": -1,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 0.206,
+          "sendEnd": 0.661,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 180.125
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.3",
+          "keyExchange": "",
+          "keyExchangeGroup": "X25519",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "*.bugsnag.com",
+          "sanList": ["*.bugsnag.com", "bugsnag.com"],
+          "issuer": "Sectigo RSA Domain Validation Secure Server CA",
+          "validFrom": 1589760000,
+          "validTo": 1621382399,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Xenon2021' log",
+              "logId": "7D3EF2F88FFF88556824C2C0CA9E5289792BC50E78097F2E6A9768997E22F0D7",
+              "timestamp": 1589800285346,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "3046022100A88FAD37FB3596C2D7366BC26664D32AFF1C82014C8ED876C20871EFEBF57867022100DEDC597BDE94B4E7E6FD45E97DE781137C8EBB5D3C24AF9FD3F74F913834941E"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Let's Encrypt 'Oak2021' log",
+              "logId": "9420BC1E8ED58D6C88731F828B222C0DD1DA4D5E6C4F943D61DB4E2F584DA2C2",
+              "timestamp": 1589800285385,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "30450220307B1EA11711911A0942EB379FE9B489BD3F073CFBAAD562425436D0A7C2FE53022100AA52AFF92057A42B9F456B6BCD03C8B90D510A02C67AF2E242538B9579CBA7B6"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.10",
+      "timestamp": 73987.326899,
+      "dataLength": 21,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.10",
+      "timestamp": 73987.327479,
+      "dataLength": 0,
+      "encodedDataLength": 39
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "9836.10",
+      "timestamp": 73987.326187,
+      "encodedDataLength": 97,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Network.requestWillBeSentExtraInfo",
+    "params": {
+      "requestId": "9836.24",
+      "associatedCookies": [],
+      "headers": {
+        ":method": "POST",
+        ":authority": "api-iam.intercom.io",
+        ":scheme": "https",
+        ":path": "/messenger/web/ping",
+        "content-length": "362",
+        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+        "content-type": "application/x-www-form-urlencoded",
+        "accept": "*/*",
+        "origin": "https://www.calibreapp.com",
+        "sec-fetch-site": "cross-site",
+        "sec-fetch-mode": "cors",
+        "sec-fetch-dest": "empty",
+        "accept-encoding": "gzip, deflate, br",
+        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8"
+      }
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "name": "networkAlmostIdle",
+      "timestamp": 73987.190876
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "name": "firstMeaningfulPaint",
+      "timestamp": 73987.144202
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "39F0C427EB9AB69251CD913A11701846",
+      "loaderId": "557CE884022B6FE686E45ABB1038FDF3",
+      "name": "networkAlmostIdle",
+      "timestamp": 73987.197781
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "5356556406F4EF152D876F82DF1B8FFA",
+      "loaderId": "CBEDEFD2D9890CDD58E15A76BD689645",
+      "name": "networkIdle",
+      "timestamp": 73987.327481
+    }
+  },
+  {
+    "method": "Network.responseReceivedExtraInfo",
+    "params": {
+      "requestId": "9836.24",
+      "blockedCookies": [],
+      "headers": {
+        "status": "200\n200 OK",
+        "date": "Tue, 28 Jul 2020 04:14:15 GMT",
+        "content-type": "application/json; charset=utf-8",
+        "cache-control": "max-age=0, private, must-revalidate",
+        "x-ratelimit-limit": "20000",
+        "x-ratelimit-reset": "1595909700",
+        "strict-transport-security": "max-age=31556952; includeSubDomains; preload",
+        "x-ratelimit-remaining": "19999",
+        "access-control-allow-origin": "https://www.calibreapp.com",
+        "x-intercom-version": "7667054cd780ad51e0687f24cb6da89c47543f03",
+        "x-xss-protection": "1; mode=block",
+        "vary": "Accept-Encoding",
+        "content-encoding": "gzip",
+        "x-request-id": "000dcplfdn3k0ti7cf8g",
+        "access-control-allow-headers": "Content-Type",
+        "access-control-allow-credentials": "true",
+        "access-control-allow-methods": "POST, GET, OPTIONS",
+        "etag": "W/\"dac0d52fbb99cf8d0996b30f81a7a5bc\"",
+        "x-runtime": "0.280061",
+        "x-frame-options": "SAMEORIGIN",
+        "x-content-type-options": "nosniff",
+        "x-ami-version": "ami-08df2120d7b03a72f",
+        "server": "nginx"
+      }
+    }
+  },
+  {
+    "method": "Network.responseReceived",
+    "params": {
+      "requestId": "9836.24",
+      "loaderId": "557CE884022B6FE686E45ABB1038FDF3",
+      "timestamp": 73988.214946,
+      "type": "XHR",
+      "response": {
+        "url": "https://api-iam.intercom.io/messenger/web/ping",
+        "status": 200,
+        "statusText": "",
+        "headers": {
+          "date": "Tue, 28 Jul 2020 04:14:15 GMT",
+          "content-encoding": "gzip",
+          "x-ami-version": "ami-08df2120d7b03a72f",
+          "status": "200, 200 OK",
+          "strict-transport-security": "max-age=31556952; includeSubDomains; preload",
+          "vary": "Accept-Encoding",
+          "x-xss-protection": "1; mode=block",
+          "x-request-id": "000dcplfdn3k0ti7cf8g",
+          "x-runtime": "0.280061",
+          "server": "nginx",
+          "x-frame-options": "SAMEORIGIN",
+          "etag": "W/\"dac0d52fbb99cf8d0996b30f81a7a5bc\"",
+          "x-ratelimit-remaining": "19999",
+          "access-control-allow-methods": "POST, GET, OPTIONS",
+          "content-type": "application/json; charset=utf-8",
+          "access-control-allow-origin": "https://www.calibreapp.com",
+          "x-intercom-version": "7667054cd780ad51e0687f24cb6da89c47543f03",
+          "cache-control": "max-age=0, private, must-revalidate",
+          "access-control-allow-credentials": "true",
+          "x-ratelimit-reset": "1595909700",
+          "x-ratelimit-limit": "20000",
+          "access-control-allow-headers": "Content-Type",
+          "x-content-type-options": "nosniff"
+        },
+        "mimeType": "application/json",
+        "connectionReused": false,
+        "connectionId": 139,
+        "remoteIPAddress": "99.83.219.81",
+        "remotePort": 443,
+        "fromDiskCache": false,
+        "fromServiceWorker": false,
+        "fromPrefetchCache": false,
+        "encodedDataLength": 631,
+        "timing": {
+          "requestTime": 73987.275787,
+          "proxyStart": -1,
+          "proxyEnd": -1,
+          "dnsStart": 0.081,
+          "dnsEnd": 18.907,
+          "connectStart": 18.907,
+          "connectEnd": 432.675,
+          "sslStart": 31.563,
+          "sslEnd": 432.671,
+          "workerStart": -1,
+          "workerReady": -1,
+          "sendStart": 432.775,
+          "sendEnd": 432.877,
+          "pushStart": 0,
+          "pushEnd": 0,
+          "receiveHeadersEnd": 937.557
+        },
+        "protocol": "h2",
+        "securityState": "secure",
+        "securityDetails": {
+          "protocol": "TLS 1.2",
+          "keyExchange": "ECDHE_RSA",
+          "keyExchangeGroup": "P-256",
+          "cipher": "AES_128_GCM",
+          "certificateId": 0,
+          "subjectName": "*.intercom.com",
+          "sanList": [
+            "*.intercom.com",
+            "intercom.io",
+            "intercom.com",
+            "*.intercom.io"
+          ],
+          "issuer": "Amazon",
+          "validFrom": 1589328000,
+          "validTo": 1623585600,
+          "signedCertificateTimestampList": [
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "Google 'Argon2021' log",
+              "logId": "F65C942FD1773022145418083094568EE34D131933BFDF0C2F200BCC4EF164E3",
+              "timestamp": 1589336958723,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "3046022100A8C88BFEAB35BEA916C11D94394084A4460897C15966AF750396D38CFBC3A9DC0221009D07DE694AD9510723E09ACD6120CA89CFBE6BFF0AEF2CE4C6026B11CBDADACB"
+            },
+            {
+              "status": "Verified",
+              "origin": "Embedded in certificate",
+              "logDescription": "DigiCert Yeti2021 Log",
+              "logId": "5CDC4392FEE6AB4544B15E9AD456E61037FBD5FA47DCA17394B25EE6F6C70ECA",
+              "timestamp": 1589336958753,
+              "hashAlgorithm": "SHA-256",
+              "signatureAlgorithm": "ECDSA",
+              "signatureData": "304402207BDDD83FBC10CFEF5790A75E2640DC1EF0464779DEF61F28D8832ABE8C559C40022068ACE99088175BE65D2EF63BC08A69909334468B923152893C38425E2910168D"
+            }
+          ],
+          "certificateTransparencyCompliance": "compliant"
+        }
+      },
+      "frameId": "39F0C427EB9AB69251CD913A11701846"
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.24",
+      "timestamp": 73988.215139,
+      "dataLength": 4931,
+      "encodedDataLength": 0
+    }
+  },
+  {
+    "method": "Network.webSocketCreated",
+    "params": {
+      "requestId": "9836.25",
+      "url": "wss://nexus-websocket-a.intercom.io/pubsub/5-cqXAzocp6giN32njR5BEOEe1VMUzFlw9Pm8ucR9_kG1t_NEzmNrkmYFiEO_qiPdQ-GJvq1yeLRAIk3UvH7oeJhoE_wNAMWKUEEFA?X-Nexus-New-Client=true&X-Nexus-Version=0.5.2&user_role=undefined",
+      "initiator": {
+        "type": "script",
+        "stack": {
+          "callFrames": [
+            {
+              "functionName": "e._initWebSocket",
+              "scriptId": "22",
+              "url": "https://js.intercomcdn.com/vendor-modern.6f14031b.js",
+              "lineNumber": 0,
+              "columnNumber": 133186
+            },
+            {
+              "functionName": "e",
+              "scriptId": "22",
+              "url": "https://js.intercomcdn.com/vendor-modern.6f14031b.js",
+              "lineNumber": 0,
+              "columnNumber": 129470
+            },
+            {
+              "functionName": "",
+              "scriptId": "22",
+              "url": "https://js.intercomcdn.com/vendor-modern.6f14031b.js",
+              "lineNumber": 0,
+              "columnNumber": 68914
+            },
+            {
+              "functionName": "e._createConnections",
+              "scriptId": "22",
+              "url": "https://js.intercomcdn.com/vendor-modern.6f14031b.js",
+              "lineNumber": 0,
+              "columnNumber": 68756
+            },
+            {
+              "functionName": "e",
+              "scriptId": "22",
+              "url": "https://js.intercomcdn.com/vendor-modern.6f14031b.js",
+              "lineNumber": 0,
+              "columnNumber": 66143
+            },
+            {
+              "functionName": "wn",
+              "scriptId": "21",
+              "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+              "lineNumber": 0,
+              "columnNumber": 141467
+            },
+            {
+              "functionName": "Rn",
+              "scriptId": "21",
+              "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+              "lineNumber": 0,
+              "columnNumber": 141720
+            },
+            {
+              "functionName": "",
+              "scriptId": "21",
+              "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+              "lineNumber": 0,
+              "columnNumber": 145586
+            },
+            {
+              "functionName": "",
+              "scriptId": "21",
+              "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+              "lineNumber": 0,
+              "columnNumber": 138161
+            },
+            {
+              "functionName": "",
+              "scriptId": "21",
+              "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+              "lineNumber": 0,
+              "columnNumber": 147973
+            },
+            {
+              "functionName": "",
+              "scriptId": "21",
+              "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+              "lineNumber": 0,
+              "columnNumber": 151404
+            },
+            {
+              "functionName": "",
+              "scriptId": "22",
+              "url": "https://js.intercomcdn.com/vendor-modern.6f14031b.js",
+              "lineNumber": 0,
+              "columnNumber": 64621
+            },
+            {
+              "functionName": "dispatch",
+              "scriptId": "22",
+              "url": "https://js.intercomcdn.com/vendor-modern.6f14031b.js",
+              "lineNumber": 0,
+              "columnNumber": 9802
+            },
+            {
+              "functionName": "",
+              "scriptId": "21",
+              "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+              "lineNumber": 0,
+              "columnNumber": 204936
+            }
+          ],
+          "parent": {
+            "description": "async function",
+            "callFrames": [
+              {
+                "functionName": "",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 203956
+              },
+              {
+                "functionName": "",
+                "scriptId": "22",
+                "url": "https://js.intercomcdn.com/vendor-modern.6f14031b.js",
+                "lineNumber": 0,
+                "columnNumber": 64612
+              },
+              {
+                "functionName": "createOrUpdateUser",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 163749
+              },
+              {
+                "functionName": "createOrUpdateUser",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 178275
+              },
+              {
+                "functionName": "boot",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 180245
+              },
+              {
+                "functionName": "",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 181347
+              },
+              {
+                "functionName": "393",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 182518
+              },
+              {
+                "functionName": "o",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 560
+              },
+              {
+                "functionName": "230",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 64316
+              },
+              {
+                "functionName": "o",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 560
+              },
+              {
+                "functionName": "229",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 64090
+              },
+              {
+                "functionName": "o",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 560
+              },
+              {
+                "functionName": "n",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 429
+              },
+              {
+                "functionName": "t",
+                "scriptId": "21",
+                "url": "https://js.intercomcdn.com/frame-modern.7ede733e.js",
+                "lineNumber": 0,
+                "columnNumber": 292
+              },
+              {
+                "functionName": "",
+                "scriptId": "22",
+                "url": "https://js.intercomcdn.com/vendor-modern.6f14031b.js",
+                "lineNumber": 0,
+                "columnNumber": 46
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  {
+    "method": "Network.dataReceived",
+    "params": {
+      "requestId": "9836.24",
+      "timestamp": 73988.226841,
+      "dataLength": 0,
+      "encodedDataLength": 1788
+    }
+  },
+  {
+    "method": "Network.loadingFinished",
+    "params": {
+      "requestId": "9836.24",
+      "timestamp": 73988.21391,
+      "encodedDataLength": 2419,
+      "shouldReportCorbBlocking": false
+    }
+  },
+  {
+    "method": "Page.lifecycleEvent",
+    "params": {
+      "frameId": "39F0C427EB9AB69251CD913A11701846",
+      "loaderId": "557CE884022B6FE686E45ABB1038FDF3",
+      "name": "networkIdle",
+      "timestamp": 73988.226848
+    }
+  },
+  {
+    "method": "Network.webSocketWillSendHandshakeRequest",
+    "params": {
+      "requestId": "9836.25",
+      "timestamp": 73988.961977,
+      "wallTime": 1595909656.447792,
+      "request": {
+        "headers": {
+          "Pragma": "no-cache",
+          "Origin": "https://www.calibreapp.com",
+          "Accept-Encoding": "gzip, deflate, br",
+          "Host": "nexus-websocket-a.intercom.io",
+          "Accept-Language": "en-GB,en-US;q=0.9,en;q=0.8",
+          "Sec-WebSocket-Key": "qD2HitMNQQfllOImY+m3Uw==",
+          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+          "Upgrade": "websocket",
+          "Sec-WebSocket-Extensions": "permessage-deflate; client_max_window_bits",
+          "Cache-Control": "no-cache",
+          "Connection": "Upgrade",
+          "Sec-WebSocket-Version": "13"
+        }
+      }
+    }
+  },
+  {
+    "method": "Network.webSocketHandshakeResponseReceived",
+    "params": {
+      "requestId": "9836.25",
+      "timestamp": 73990.117375,
+      "response": {
+        "status": 101,
+        "statusText": "Switching Protocols",
+        "headers": {
+          "Date": "Tue, 28 Jul 2020 04:14:17 GMT",
+          "Sec-WebSocket-Accept": "Gv8AQqJsLCJnK0V1wGIggj+o4v8=",
+          "Server": "nginx",
+          "Connection": "upgrade",
+          "Upgrade": "websocket"
+        },
+        "headersText": "HTTP/1.1 101 Switching Protocols\r\nServer: nginx\r\nDate: Tue, 28 Jul 2020 04:14:17 GMT\r\nConnection: upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Accept: Gv8AQqJsLCJnK0V1wGIggj+o4v8=\r\n\r\n",
+        "requestHeaders": {
+          "Pragma": "no-cache",
+          "Origin": "https://www.calibreapp.com",
+          "Accept-Encoding": "gzip, deflate, br",
+          "Host": "nexus-websocket-a.intercom.io",
+          "Accept-Language": "en-GB,en-US;q=0.9,en;q=0.8",
+          "Sec-WebSocket-Key": "qD2HitMNQQfllOImY+m3Uw==",
+          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36",
+          "Upgrade": "websocket",
+          "Sec-WebSocket-Extensions": "permessage-deflate; client_max_window_bits",
+          "Cache-Control": "no-cache",
+          "Connection": "Upgrade",
+          "Sec-WebSocket-Version": "13"
+        },
+        "requestHeadersText": "GET wss://nexus-websocket-a.intercom.io/pubsub/5-cqXAzocp6giN32njR5BEOEe1VMUzFlw9Pm8ucR9_kG1t_NEzmNrkmYFiEO_qiPdQ-GJvq1yeLRAIk3UvH7oeJhoE_wNAMWKUEEFA?X-Nexus-New-Client=true&X-Nexus-Version=0.5.2&user_role=undefined HTTP/1.1\r\nHost: nexus-websocket-a.intercom.io\r\nConnection: Upgrade\r\nPragma: no-cache\r\nCache-Control: no-cache\r\nUser-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36\r\nUpgrade: websocket\r\nOrigin: https://www.calibreapp.com\r\nSec-WebSocket-Version: 13\r\nAccept-Encoding: gzip, deflate, br\r\nAccept-Language: en-GB,en-US;q=0.9,en;q=0.8\r\nSec-WebSocket-Key: qD2HitMNQQfllOImY+m3Uw==\r\nSec-WebSocket-Extensions: permessage-deflate; client_max_window_bits\r\n\r\n"
+      }
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "9836.25",
+      "timestamp": 73990.118744,
+      "response": {
+        "opcode": 1,
+        "mask": true,
+        "payloadData": "{\"eventName\":\"nx.UserPresence\",\"eventData\":{\"current_page\":\"https://www.calibreapp.com/sign-in\"}}"
+      }
+    }
+  },
+  {
+    "method": "Network.webSocketFrameSent",
+    "params": {
+      "requestId": "9836.25",
+      "timestamp": 73990.11898,
+      "response": {
+        "opcode": 1,
+        "mask": true,
+        "payloadData": "{\"eventName\":\"nx.Subscribe\",\"nx.Topics\":[\"*\"]}"
+      }
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "9836.25",
+      "timestamp": 73990.119275,
+      "response": { "opcode": 1, "mask": false, "payloadData": "" }
+    }
+  },
+  {
+    "method": "Network.webSocketFrameReceived",
+    "params": {
+      "requestId": "9836.25",
+      "timestamp": 73990.1198,
+      "response": {
+        "opcode": 1,
+        "mask": false,
+        "payloadData": "0xc2f45d1680 |0| |"
+      }
+    }
+  }
+]

--- a/test/tests.js
+++ b/test/tests.js
@@ -195,3 +195,41 @@ test("Includes extra info in request", t => {
       t.is(cssAsset.request.headers.length, 15);
     });
 });
+
+test("Includes extra info in response", t => {
+  const perflogPath = perflog("www.calibreapp.com.signin.json");
+  return parsePerflog(perflogPath)
+    .then(har => har.log)
+    .tap(log => {
+      const cssAsset = log.entries.find(e =>
+        e.request.url.endsWith(
+          "sign_up_in-8b32538e54b23b40f8fd45c28abdcee2e2d023bd7e01ddf2033d5f781afae9dc.css"
+        )
+      );
+      t.is(cssAsset.response.headers.length, 14);
+    });
+});
+
+test("Excludes request blocked cookies", t => {
+  const perflogPath = perflog("samesite-sandbox.glitch.me.json");
+  return parsePerflog(perflogPath)
+    .then(har => har.log)
+    .tap(log => {
+      const cookiesAsset = log.entries.find(e =>
+        e.request.url.endsWith("cookies.json")
+      );
+      t.is(cookiesAsset.request.cookies.length, 4);
+    });
+});
+
+test("Excludes response blocked cookies", t => {
+  const perflogPath = perflog("response-blocked-cookies.json");
+  return parsePerflog(perflogPath)
+    .then(har => har.log)
+    .tap(log => {
+      const request = log.entries.find(
+        e => e.request.url === "https://ow5u1.sse.codesandbox.io/"
+      );
+      t.is(request.response.cookies.length, 1);
+    });
+});

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,20 +1,20 @@
-import test from "ava";
-import * as validator from "har-validator";
-import * as Promise from "bluebird";
-import * as fs from "fs";
-import * as path from "path";
-import parser from "../";
+import test from 'ava';
+import * as validator from 'har-validator';
+import * as Promise from 'bluebird';
+import * as fs from 'fs';
+import * as path from 'path';
+import parser from '../';
 
 Promise.promisifyAll(fs);
 
-const PERFLOGSPATH = path.resolve(__dirname, "perflogs");
+const PERFLOGSPATH = path.resolve(__dirname, 'perflogs');
 
 /**
  * Validate that, for each tcp connection, the previous request is fully completed before then next starts.
  */
 function validateConnectionOverlap(t, entries) {
   const entriesByConnection = entries
-    .filter(entry => !["h2", "spdy/3.1"].includes(entry.response.httpVersion))
+    .filter(entry => !['h2', 'spdy/3.1'].includes(entry.response.httpVersion))
     .filter(entry => !(entry.cache || {}).beforeRequest)
     .reduce((entries, entry) => {
       const e = entries.get(entry.connection) || [];
@@ -45,7 +45,7 @@ function perflog(filename) {
 function perflogs() {
   return fs
     .readdirAsync(PERFLOGSPATH)
-    .filter(filename => path.extname(filename) === ".json");
+    .filter(filename => path.extname(filename) === '.json');
 }
 
 function parsePerflog(perflogPath, options) {
@@ -74,72 +74,72 @@ function testAllHARs(t, options) {
   });
 }
 
-test("Generates valid HARs", t => {
+test('Generates valid HARs', t => {
   return testAllHARs(t);
 });
 
-test("Generates valid HARs including cached entries", t => {
+test('Generates valid HARs including cached entries', t => {
   return testAllHARs(t, { includeResourcesFromDiskCache: true });
 });
 
-test("zdnet", t => {
-  const perflogPath = perflog("www.zdnet.com.json");
+test('zdnet', t => {
+  const perflogPath = perflog('www.zdnet.com.json');
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => t.is(log.pages.length, 1))
     .tap(log => t.is(log.entries.length, 343));
 });
 
-test("ryan", t => {
-  const perflogPath = perflog("ryan.json");
+test('ryan', t => {
+  const perflogPath = perflog('ryan.json');
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => t.is(log.pages.length, 1));
 });
 
-test("chrome66", t => {
-  const perflogPath = perflog("www.sitepeed.io.chrome66.json");
+test('chrome66', t => {
+  const perflogPath = perflog('www.sitepeed.io.chrome66.json');
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => t.is(log.entries.length, 9));
 });
 
-test("Parses IPv6 address", t => {
-  const perflogPath = perflog("www.google.ru.json");
+test('Parses IPv6 address', t => {
+  const perflogPath = perflog('www.google.ru.json');
   return parsePerflog(perflogPath).then(har =>
-    t.is(har.log.entries[0].serverIPAddress, "2a00:1450:400f:80a::2003")
+    t.is(har.log.entries[0].serverIPAddress, '2a00:1450:400f:80a::2003')
   );
 });
 
-test("navigatedWithinDocument", t => {
-  const perflogPath = perflog("navigatedWithinDocument.json");
+test('navigatedWithinDocument', t => {
+  const perflogPath = perflog('navigatedWithinDocument.json');
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => t.is(log.entries.length, 1));
 });
 
-test("Generates multiple pages", t => {
-  const perflogPath = perflog("www.wikipedia.org.json");
+test('Generates multiple pages', t => {
+  const perflogPath = perflog('www.wikipedia.org.json');
   return parsePerflog(perflogPath).tap(har => t.is(har.log.pages.length, 2));
 });
 
-test("Skips empty pages", t => {
-  const perflogPath = perflog("www.wikipedia.org-empty.json");
+test('Skips empty pages', t => {
+  const perflogPath = perflog('www.wikipedia.org-empty.json');
   return parsePerflog(perflogPath).tap(har => t.is(har.log.pages.length, 1));
 });
 
-test("Click on link in Chrome should create new page", t => {
-  const perflogPath = perflog("linkClickChrome.json");
+test('Click on link in Chrome should create new page', t => {
+  const perflogPath = perflog('linkClickChrome.json');
   return parsePerflog(perflogPath).tap(har => t.is(har.log.pages.length, 1));
 });
 
-test("Includes pushed assets", t => {
-  const perflogPath = perflog("akamai-h2push.json");
+test('Includes pushed assets', t => {
+  const perflogPath = perflog('akamai-h2push.json');
   return parsePerflog(perflogPath)
     .tap(har => t.is(har.log.pages.length, 1))
     .tap(har => {
       const images = har.log.entries.filter(e =>
-        e.request.url.startsWith("https://http2.akamai.com/demo/tile-")
+        e.request.url.startsWith('https://http2.akamai.com/demo/tile-')
       );
       t.is(images.length, 361); // 19*19 = 361 image tiles
 
@@ -148,8 +148,8 @@ test("Includes pushed assets", t => {
     });
 });
 
-test("Includes response bodies", t => {
-  const perflogPath = perflog("www.sitepeed.io.chrome66.json");
+test('Includes response bodies', t => {
+  const perflogPath = perflog('www.sitepeed.io.chrome66.json');
   return parsePerflog(perflogPath, { includeTextFromResponseBody: true })
     .then(har => har.log)
     .tap(log =>
@@ -157,78 +157,78 @@ test("Includes response bodies", t => {
     );
 });
 
-test("Includes canceled response", t => {
-  const perflogPath = perflog("canceled-video.json");
+test('Includes canceled response', t => {
+  const perflogPath = perflog('canceled-video.json');
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => {
       const videoAsset = log.entries.find(
-        e => e.request.url === "https://www.w3schools.com/tags/movie.mp4"
+        e => e.request.url === 'https://www.w3schools.com/tags/movie.mp4'
       );
       t.is(videoAsset.timings.receive, 316.563);
       t.is(videoAsset.time, 343.33099999999996);
     });
 });
 
-test("Includes iframe request when frame is not attached", t => {
-  const perflogPath = perflog("iframe-not-attached.json");
+test('Includes iframe request when frame is not attached', t => {
+  const perflogPath = perflog('iframe-not-attached.json');
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => {
       const imageAsset = log.entries.filter(
-        e => e.request.url === "https://www.w3schools.com/html/img_girl.jpg"
+        e => e.request.url === 'https://www.w3schools.com/html/img_girl.jpg'
       );
       t.is(imageAsset.length, 1);
     });
 });
 
-test("Includes extra info in request", t => {
-  const perflogPath = perflog("www.calibreapp.com.signin.json");
+test('Includes extra info in request', t => {
+  const perflogPath = perflog('www.calibreapp.com.signin.json');
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => {
       const cssAsset = log.entries.find(e =>
         e.request.url.endsWith(
-          "sign_up_in-8b32538e54b23b40f8fd45c28abdcee2e2d023bd7e01ddf2033d5f781afae9dc.css"
+          'sign_up_in-8b32538e54b23b40f8fd45c28abdcee2e2d023bd7e01ddf2033d5f781afae9dc.css'
         )
       );
       t.is(cssAsset.request.headers.length, 15);
     });
 });
 
-test("Includes extra info in response", t => {
-  const perflogPath = perflog("www.calibreapp.com.signin.json");
+test('Includes extra info in response', t => {
+  const perflogPath = perflog('www.calibreapp.com.signin.json');
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => {
       const cssAsset = log.entries.find(e =>
         e.request.url.endsWith(
-          "sign_up_in-8b32538e54b23b40f8fd45c28abdcee2e2d023bd7e01ddf2033d5f781afae9dc.css"
+          'sign_up_in-8b32538e54b23b40f8fd45c28abdcee2e2d023bd7e01ddf2033d5f781afae9dc.css'
         )
       );
       t.is(cssAsset.response.headers.length, 14);
     });
 });
 
-test("Excludes request blocked cookies", t => {
-  const perflogPath = perflog("samesite-sandbox.glitch.me.json");
+test('Excludes request blocked cookies', t => {
+  const perflogPath = perflog('samesite-sandbox.glitch.me.json');
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => {
       const cookiesAsset = log.entries.find(e =>
-        e.request.url.endsWith("cookies.json")
+        e.request.url.endsWith('cookies.json')
       );
       t.is(cookiesAsset.request.cookies.length, 4);
     });
 });
 
-test("Excludes response blocked cookies", t => {
-  const perflogPath = perflog("response-blocked-cookies.json");
+test('Excludes response blocked cookies', t => {
+  const perflogPath = perflog('response-blocked-cookies.json');
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => {
       const request = log.entries.find(
-        e => e.request.url === "https://ow5u1.sse.codesandbox.io/"
+        e => e.request.url === 'https://ow5u1.sse.codesandbox.io/'
       );
       t.is(request.response.cookies.length, 1);
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,20 +1,20 @@
-import test from 'ava';
-import * as validator from 'har-validator';
-import * as Promise from 'bluebird';
-import * as fs from 'fs';
-import * as path from 'path';
-import parser from '../';
+import test from "ava";
+import * as validator from "har-validator";
+import * as Promise from "bluebird";
+import * as fs from "fs";
+import * as path from "path";
+import parser from "../";
 
 Promise.promisifyAll(fs);
 
-const PERFLOGSPATH = path.resolve(__dirname, 'perflogs');
+const PERFLOGSPATH = path.resolve(__dirname, "perflogs");
 
 /**
  * Validate that, for each tcp connection, the previous request is fully completed before then next starts.
  */
 function validateConnectionOverlap(t, entries) {
   const entriesByConnection = entries
-    .filter(entry => !['h2', 'spdy/3.1'].includes(entry.response.httpVersion))
+    .filter(entry => !["h2", "spdy/3.1"].includes(entry.response.httpVersion))
     .filter(entry => !(entry.cache || {}).beforeRequest)
     .reduce((entries, entry) => {
       const e = entries.get(entry.connection) || [];
@@ -45,7 +45,7 @@ function perflog(filename) {
 function perflogs() {
   return fs
     .readdirAsync(PERFLOGSPATH)
-    .filter(filename => path.extname(filename) === '.json');
+    .filter(filename => path.extname(filename) === ".json");
 }
 
 function parsePerflog(perflogPath, options) {
@@ -74,72 +74,72 @@ function testAllHARs(t, options) {
   });
 }
 
-test('Generates valid HARs', t => {
+test("Generates valid HARs", t => {
   return testAllHARs(t);
 });
 
-test('Generates valid HARs including cached entries', t => {
+test("Generates valid HARs including cached entries", t => {
   return testAllHARs(t, { includeResourcesFromDiskCache: true });
 });
 
-test('zdnet', t => {
-  const perflogPath = perflog('www.zdnet.com.json');
+test("zdnet", t => {
+  const perflogPath = perflog("www.zdnet.com.json");
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => t.is(log.pages.length, 1))
     .tap(log => t.is(log.entries.length, 343));
 });
 
-test('ryan', t => {
-  const perflogPath = perflog('ryan.json');
+test("ryan", t => {
+  const perflogPath = perflog("ryan.json");
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => t.is(log.pages.length, 1));
 });
 
-test('chrome66', t => {
-  const perflogPath = perflog('www.sitepeed.io.chrome66.json');
+test("chrome66", t => {
+  const perflogPath = perflog("www.sitepeed.io.chrome66.json");
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => t.is(log.entries.length, 9));
 });
 
-test('Parses IPv6 address', t => {
-  const perflogPath = perflog('www.google.ru.json');
+test("Parses IPv6 address", t => {
+  const perflogPath = perflog("www.google.ru.json");
   return parsePerflog(perflogPath).then(har =>
-    t.is(har.log.entries[0].serverIPAddress, '2a00:1450:400f:80a::2003')
+    t.is(har.log.entries[0].serverIPAddress, "2a00:1450:400f:80a::2003")
   );
 });
 
-test('navigatedWithinDocument', t => {
-  const perflogPath = perflog('navigatedWithinDocument.json');
+test("navigatedWithinDocument", t => {
+  const perflogPath = perflog("navigatedWithinDocument.json");
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => t.is(log.entries.length, 1));
 });
 
-test('Generates multiple pages', t => {
-  const perflogPath = perflog('www.wikipedia.org.json');
+test("Generates multiple pages", t => {
+  const perflogPath = perflog("www.wikipedia.org.json");
   return parsePerflog(perflogPath).tap(har => t.is(har.log.pages.length, 2));
 });
 
-test('Skips empty pages', t => {
-  const perflogPath = perflog('www.wikipedia.org-empty.json');
+test("Skips empty pages", t => {
+  const perflogPath = perflog("www.wikipedia.org-empty.json");
   return parsePerflog(perflogPath).tap(har => t.is(har.log.pages.length, 1));
 });
 
-test('Click on link in Chrome should create new page', t => {
-  const perflogPath = perflog('linkClickChrome.json');
+test("Click on link in Chrome should create new page", t => {
+  const perflogPath = perflog("linkClickChrome.json");
   return parsePerflog(perflogPath).tap(har => t.is(har.log.pages.length, 1));
 });
 
-test('Includes pushed assets', t => {
-  const perflogPath = perflog('akamai-h2push.json');
+test("Includes pushed assets", t => {
+  const perflogPath = perflog("akamai-h2push.json");
   return parsePerflog(perflogPath)
     .tap(har => t.is(har.log.pages.length, 1))
     .tap(har => {
       const images = har.log.entries.filter(e =>
-        e.request.url.startsWith('https://http2.akamai.com/demo/tile-')
+        e.request.url.startsWith("https://http2.akamai.com/demo/tile-")
       );
       t.is(images.length, 361); // 19*19 = 361 image tiles
 
@@ -148,8 +148,8 @@ test('Includes pushed assets', t => {
     });
 });
 
-test('Includes response bodies', t => {
-  const perflogPath = perflog('www.sitepeed.io.chrome66.json');
+test("Includes response bodies", t => {
+  const perflogPath = perflog("www.sitepeed.io.chrome66.json");
   return parsePerflog(perflogPath, { includeTextFromResponseBody: true })
     .then(har => har.log)
     .tap(log =>
@@ -157,27 +157,41 @@ test('Includes response bodies', t => {
     );
 });
 
-test('Includes canceled response', t => {
-  const perflogPath = perflog('canceled-video.json');
+test("Includes canceled response", t => {
+  const perflogPath = perflog("canceled-video.json");
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => {
       const videoAsset = log.entries.find(
-        e => e.request.url === 'https://www.w3schools.com/tags/movie.mp4'
+        e => e.request.url === "https://www.w3schools.com/tags/movie.mp4"
       );
       t.is(videoAsset.timings.receive, 316.563);
       t.is(videoAsset.time, 343.33099999999996);
     });
 });
 
-test('Includes iframe request when frame is not attached', t => {
-  const perflogPath = perflog('iframe-not-attached.json');
+test("Includes iframe request when frame is not attached", t => {
+  const perflogPath = perflog("iframe-not-attached.json");
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => {
       const imageAsset = log.entries.filter(
-        e => e.request.url === 'https://www.w3schools.com/html/img_girl.jpg'
+        e => e.request.url === "https://www.w3schools.com/html/img_girl.jpg"
       );
       t.is(imageAsset.length, 1);
+    });
+});
+
+test("Includes extra info in request", t => {
+  const perflogPath = perflog("www.calibreapp.com.signin.json");
+  return parsePerflog(perflogPath)
+    .then(har => har.log)
+    .tap(log => {
+      const cssAsset = log.entries.find(e =>
+        e.request.url.endsWith(
+          "sign_up_in-8b32538e54b23b40f8fd45c28abdcee2e2d023bd7e01ddf2033d5f781afae9dc.css"
+        )
+      );
+      t.is(cssAsset.request.headers.length, 15);
     });
 });


### PR DESCRIPTION
This PR will:

- Parse extra request data from the `Network.requestWillBeSentExtraInfo` event
- Parse extra response data from the `Network.responseReceivedExtraInfo` event

From my testing, the `Network.requestWillBeSentExtraInfo` event will always arrive after the `Network.requestWillBeSent` event, however the `Network.responseReceivedExtraInfo` can fire before the `Network.responseReceived` event, therefore we need to temporarily cache the extra info and parse it with the response to correctly attribute headers and cookies.

Closes #70 