### PR TITLE
Fix: Optional cookie object

### DIFF
--- a/lib/entryFromResponse.js
+++ b/lib/entryFromResponse.js
@@ -1,5 +1,5 @@
-"use strict";
-const dayjs = require("dayjs");
+'use strict';
+const dayjs = require('dayjs');
 const max = Math.max;
 
 const {
@@ -7,10 +7,10 @@ const {
   calculateResponseHeaderSize,
   getHeaderValue,
   parseHeaders
-} = require("./headers");
+} = require('./headers');
 
-const { parseRequestCookies, parseResponseCookies } = require("./cookies");
-const { isHttp1x, formatMillis } = require("./util");
+const { parseRequestCookies, parseResponseCookies } = require('./cookies');
+const { isHttp1x, formatMillis } = require('./util');
 function firstNonNegative(values) {
   for (let i = 0; i < values.length; ++i) {
     if (values[i] >= 0) return values[i];
@@ -19,16 +19,16 @@ function firstNonNegative(values) {
 }
 
 function formatIP(ipAddress) {
-  if (typeof ipAddress !== "string") {
+  if (typeof ipAddress !== 'string') {
     return undefined;
   }
   // IPv6 addresses are listed as [2a00:1450:400f:80a::2003]
-  return ipAddress.replace(/^\[|]$/g, "");
+  return ipAddress.replace(/^\[|]$/g, '');
 }
 
 module.exports = function(entry, response, page, options) {
   const responseHeaders = response.headers;
-  const cookieHeader = getHeaderValue(responseHeaders, "Set-Cookie");
+  const cookieHeader = getHeaderValue(responseHeaders, 'Set-Cookie');
 
   let cookies = parseResponseCookies(cookieHeader);
   let headers = parseHeaders(responseHeaders);
@@ -75,7 +75,7 @@ module.exports = function(entry, response, page, options) {
 
   entry.response = {
     httpVersion: response.protocol,
-    redirectURL: "",
+    redirectURL: '',
     status: response.status,
     statusText: response.statusText,
     content: {
@@ -90,7 +90,7 @@ module.exports = function(entry, response, page, options) {
     _transferSize: response.encodedDataLength
   };
 
-  const locationHeaderValue = getHeaderValue(responseHeaders, "Location");
+  const locationHeaderValue = getHeaderValue(responseHeaders, 'Location');
   if (locationHeaderValue) {
     entry.response.redirectURL = locationHeaderValue;
   }
@@ -106,8 +106,8 @@ module.exports = function(entry, response, page, options) {
     // h2 push might cause resource to be received before parser sees and requests it.
     if (response.timing && !(response.timing.pushStart > 0)) {
       entry.cache.beforeRequest = {
-        lastAccess: "",
-        eTag: "",
+        lastAccess: '',
+        eTag: '',
         hitCount: 0
       };
     }
@@ -115,7 +115,7 @@ module.exports = function(entry, response, page, options) {
     if (response.requestHeaders) {
       entry.request.headers = parseHeaders(response.requestHeaders);
 
-      const cookieHeader = getHeaderValue(response.requestHeaders, "Cookie");
+      const cookieHeader = getHeaderValue(response.requestHeaders, 'Cookie');
       entry.request.cookies = parseRequestCookies(cookieHeader);
     }
 
@@ -154,13 +154,13 @@ module.exports = function(entry, response, page, options) {
       firstNonNegative([timing.dnsStart, timing.connectStart, timing.sendStart])
     );
 
-    const dns = parseOptionalTime(timing, "dnsStart", "dnsEnd");
-    const connect = parseOptionalTime(timing, "connectStart", "connectEnd");
+    const dns = parseOptionalTime(timing, 'dnsStart', 'dnsEnd');
+    const connect = parseOptionalTime(timing, 'connectStart', 'connectEnd');
     const send = formatMillis(timing.sendEnd - timing.sendStart);
     const wait = formatMillis(timing.receiveHeadersEnd - timing.sendEnd);
     const receive = 0;
 
-    const ssl = parseOptionalTime(timing, "sslStart", "sslEnd");
+    const ssl = parseOptionalTime(timing, 'sslStart', 'sslEnd');
 
     entry.timings = {
       blocked,
@@ -211,7 +211,7 @@ module.exports = function(entry, response, page, options) {
       wait: 0,
       receive: 0,
       ssl: -1,
-      comment: "No timings available from Chrome"
+      comment: 'No timings available from Chrome'
     };
     entry.time = 0;
   }

--- a/lib/entryFromResponse.js
+++ b/lib/entryFromResponse.js
@@ -1,5 +1,5 @@
-'use strict';
-const dayjs = require('dayjs');
+"use strict";
+const dayjs = require("dayjs");
 const max = Math.max;
 
 const {
@@ -7,10 +7,10 @@ const {
   calculateResponseHeaderSize,
   getHeaderValue,
   parseHeaders
-} = require('./headers');
+} = require("./headers");
 
-const { parseRequestCookies, parseResponseCookies } = require('./cookies');
-const { isHttp1x, formatMillis } = require('./util');
+const { parseRequestCookies, parseResponseCookies } = require("./cookies");
+const { isHttp1x, formatMillis } = require("./util");
 function firstNonNegative(values) {
   for (let i = 0; i < values.length; ++i) {
     if (values[i] >= 0) return values[i];
@@ -19,16 +19,16 @@ function firstNonNegative(values) {
 }
 
 function formatIP(ipAddress) {
-  if (typeof ipAddress !== 'string') {
+  if (typeof ipAddress !== "string") {
     return undefined;
   }
   // IPv6 addresses are listed as [2a00:1450:400f:80a::2003]
-  return ipAddress.replace(/^\[|]$/g, '');
+  return ipAddress.replace(/^\[|]$/g, "");
 }
 
 module.exports = function(entry, response, page, options) {
   const responseHeaders = response.headers;
-  const cookieHeader = getHeaderValue(responseHeaders, 'Set-Cookie');
+  const cookieHeader = getHeaderValue(responseHeaders, "Set-Cookie");
 
   let cookies = parseResponseCookies(cookieHeader);
   let headers = parseHeaders(responseHeaders);
@@ -45,9 +45,18 @@ module.exports = function(entry, response, page, options) {
     if (entry.extraResponseInfo.blockedCookies) {
       cookies = cookies.filter(
         ({ name }) =>
-          !entry.extraResponseInfo.blockedCookies.find(
-            ({ cookie }) => cookie.name === name
-          )
+          !entry.extraResponseInfo.blockedCookies.find(blockedCookie => {
+            if (blockedCookie.cookie) {
+              return blockedCookie.cookie.name === name;
+            } else if (blockedCookie.cookieLine) {
+              const cookie = parseResponseCookies(blockedCookie.cookieLine)[0];
+              if (cookie) {
+                return cookie.name === name;
+              }
+            }
+
+            return false;
+          })
       );
     }
 
@@ -66,7 +75,7 @@ module.exports = function(entry, response, page, options) {
 
   entry.response = {
     httpVersion: response.protocol,
-    redirectURL: '',
+    redirectURL: "",
     status: response.status,
     statusText: response.statusText,
     content: {
@@ -81,7 +90,7 @@ module.exports = function(entry, response, page, options) {
     _transferSize: response.encodedDataLength
   };
 
-  const locationHeaderValue = getHeaderValue(responseHeaders, 'Location');
+  const locationHeaderValue = getHeaderValue(responseHeaders, "Location");
   if (locationHeaderValue) {
     entry.response.redirectURL = locationHeaderValue;
   }
@@ -97,8 +106,8 @@ module.exports = function(entry, response, page, options) {
     // h2 push might cause resource to be received before parser sees and requests it.
     if (response.timing && !(response.timing.pushStart > 0)) {
       entry.cache.beforeRequest = {
-        lastAccess: '',
-        eTag: '',
+        lastAccess: "",
+        eTag: "",
         hitCount: 0
       };
     }
@@ -106,7 +115,7 @@ module.exports = function(entry, response, page, options) {
     if (response.requestHeaders) {
       entry.request.headers = parseHeaders(response.requestHeaders);
 
-      const cookieHeader = getHeaderValue(response.requestHeaders, 'Cookie');
+      const cookieHeader = getHeaderValue(response.requestHeaders, "Cookie");
       entry.request.cookies = parseRequestCookies(cookieHeader);
     }
 
@@ -145,13 +154,13 @@ module.exports = function(entry, response, page, options) {
       firstNonNegative([timing.dnsStart, timing.connectStart, timing.sendStart])
     );
 
-    const dns = parseOptionalTime(timing, 'dnsStart', 'dnsEnd');
-    const connect = parseOptionalTime(timing, 'connectStart', 'connectEnd');
+    const dns = parseOptionalTime(timing, "dnsStart", "dnsEnd");
+    const connect = parseOptionalTime(timing, "connectStart", "connectEnd");
     const send = formatMillis(timing.sendEnd - timing.sendStart);
     const wait = formatMillis(timing.receiveHeadersEnd - timing.sendEnd);
     const receive = 0;
 
-    const ssl = parseOptionalTime(timing, 'sslStart', 'sslEnd');
+    const ssl = parseOptionalTime(timing, "sslStart", "sslEnd");
 
     entry.timings = {
       blocked,
@@ -202,7 +211,7 @@ module.exports = function(entry, response, page, options) {
       wait: 0,
       receive: 0,
       ssl: -1,
-      comment: 'No timings available from Chrome'
+      comment: "No timings available from Chrome"
     };
     entry.time = 0;
   }

--- a/test/perflogs/response-blocked-cookies.json
+++ b/test/perflogs/response-blocked-cookies.json
@@ -407,20 +407,7 @@
         {
           "blockedReasons": ["SameSiteLax"],
           "cookieLine":
-            "__cfduid=d4ce688e8643102b51bf01817fcbfaf431595998349; expires=Fri, 28-Aug-20 04:52:29 GMT; path=/; domain=.codesandbox.io; HttpOnly; SameSite=Lax; Secure",
-          "cookie": {
-            "name": "__cfduid",
-            "value": "d4ce688e8643102b51bf01817fcbfaf431595998349",
-            "domain": ".codesandbox.io",
-            "path": "/",
-            "expires": 1598590349.143488,
-            "size": 51,
-            "httpOnly": true,
-            "secure": true,
-            "session": false,
-            "sameSite": "Lax",
-            "priority": "Medium"
-          }
+            "__cfduid=d4ce688e8643102b51bf01817fcbfaf431595998349; expires=Fri, 28-Aug-20 04:52:29 GMT; path=/; domain=.codesandbox.io; HttpOnly; SameSite=Lax; Secure"
         }
       ],
       "headers": {
@@ -718,20 +705,7 @@
         {
           "blockedReasons": ["SameSiteLax"],
           "cookieLine":
-            "__cfduid=d1a3eeb06208778c719235145dfee08521595998350; expires=Fri, 28-Aug-20 04:52:30 GMT; path=/; domain=.codesandbox.io; HttpOnly; SameSite=Lax; Secure",
-          "cookie": {
-            "name": "__cfduid",
-            "value": "d1a3eeb06208778c719235145dfee08521595998350",
-            "domain": ".codesandbox.io",
-            "path": "/",
-            "expires": 1598590350.519569,
-            "size": 51,
-            "httpOnly": true,
-            "secure": true,
-            "session": false,
-            "sameSite": "Lax",
-            "priority": "Medium"
-          }
+            "__cfduid=d1a3eeb06208778c719235145dfee08521595998350; expires=Fri, 28-Aug-20 04:52:30 GMT; path=/; domain=.codesandbox.io; HttpOnly; SameSite=Lax; Secure"
         }
       ],
       "headers": {

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,20 +1,20 @@
-import test from "ava";
-import * as validator from "har-validator";
-import * as Promise from "bluebird";
-import * as fs from "fs";
-import * as path from "path";
-import parser from "../";
+import test from 'ava';
+import * as validator from 'har-validator';
+import * as Promise from 'bluebird';
+import * as fs from 'fs';
+import * as path from 'path';
+import parser from '../';
 
 Promise.promisifyAll(fs);
 
-const PERFLOGSPATH = path.resolve(__dirname, "perflogs");
+const PERFLOGSPATH = path.resolve(__dirname, 'perflogs');
 
 /**
  * Validate that, for each tcp connection, the previous request is fully completed before then next starts.
  */
 function validateConnectionOverlap(t, entries) {
   const entriesByConnection = entries
-    .filter(entry => !["h2", "spdy/3.1"].includes(entry.response.httpVersion))
+    .filter(entry => !['h2', 'spdy/3.1'].includes(entry.response.httpVersion))
     .filter(entry => !(entry.cache || {}).beforeRequest)
     .reduce((entries, entry) => {
       const e = entries.get(entry.connection) || [];
@@ -45,7 +45,7 @@ function perflog(filename) {
 function perflogs() {
   return fs
     .readdirAsync(PERFLOGSPATH)
-    .filter(filename => path.extname(filename) === ".json");
+    .filter(filename => path.extname(filename) === '.json');
 }
 
 function parsePerflog(perflogPath, options) {
@@ -74,72 +74,72 @@ function testAllHARs(t, options) {
   });
 }
 
-test("Generates valid HARs", t => {
+test('Generates valid HARs', t => {
   return testAllHARs(t);
 });
 
-test("Generates valid HARs including cached entries", t => {
+test('Generates valid HARs including cached entries', t => {
   return testAllHARs(t, { includeResourcesFromDiskCache: true });
 });
 
-test("zdnet", t => {
-  const perflogPath = perflog("www.zdnet.com.json");
+test('zdnet', t => {
+  const perflogPath = perflog('www.zdnet.com.json');
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => t.is(log.pages.length, 1))
     .tap(log => t.is(log.entries.length, 343));
 });
 
-test("ryan", t => {
-  const perflogPath = perflog("ryan.json");
+test('ryan', t => {
+  const perflogPath = perflog('ryan.json');
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => t.is(log.pages.length, 1));
 });
 
-test("chrome66", t => {
-  const perflogPath = perflog("www.sitepeed.io.chrome66.json");
+test('chrome66', t => {
+  const perflogPath = perflog('www.sitepeed.io.chrome66.json');
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => t.is(log.entries.length, 9));
 });
 
-test("Parses IPv6 address", t => {
-  const perflogPath = perflog("www.google.ru.json");
+test('Parses IPv6 address', t => {
+  const perflogPath = perflog('www.google.ru.json');
   return parsePerflog(perflogPath).then(har =>
-    t.is(har.log.entries[0].serverIPAddress, "2a00:1450:400f:80a::2003")
+    t.is(har.log.entries[0].serverIPAddress, '2a00:1450:400f:80a::2003')
   );
 });
 
-test("navigatedWithinDocument", t => {
-  const perflogPath = perflog("navigatedWithinDocument.json");
+test('navigatedWithinDocument', t => {
+  const perflogPath = perflog('navigatedWithinDocument.json');
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => t.is(log.entries.length, 1));
 });
 
-test("Generates multiple pages", t => {
-  const perflogPath = perflog("www.wikipedia.org.json");
+test('Generates multiple pages', t => {
+  const perflogPath = perflog('www.wikipedia.org.json');
   return parsePerflog(perflogPath).tap(har => t.is(har.log.pages.length, 2));
 });
 
-test("Skips empty pages", t => {
-  const perflogPath = perflog("www.wikipedia.org-empty.json");
+test('Skips empty pages', t => {
+  const perflogPath = perflog('www.wikipedia.org-empty.json');
   return parsePerflog(perflogPath).tap(har => t.is(har.log.pages.length, 1));
 });
 
-test("Click on link in Chrome should create new page", t => {
-  const perflogPath = perflog("linkClickChrome.json");
+test('Click on link in Chrome should create new page', t => {
+  const perflogPath = perflog('linkClickChrome.json');
   return parsePerflog(perflogPath).tap(har => t.is(har.log.pages.length, 1));
 });
 
-test("Includes pushed assets", t => {
-  const perflogPath = perflog("akamai-h2push.json");
+test('Includes pushed assets', t => {
+  const perflogPath = perflog('akamai-h2push.json');
   return parsePerflog(perflogPath)
     .tap(har => t.is(har.log.pages.length, 1))
     .tap(har => {
       const images = har.log.entries.filter(e =>
-        e.request.url.startsWith("https://http2.akamai.com/demo/tile-")
+        e.request.url.startsWith('https://http2.akamai.com/demo/tile-')
       );
       t.is(images.length, 361); // 19*19 = 361 image tiles
 
@@ -148,8 +148,8 @@ test("Includes pushed assets", t => {
     });
 });
 
-test("Includes response bodies", t => {
-  const perflogPath = perflog("www.sitepeed.io.chrome66.json");
+test('Includes response bodies', t => {
+  const perflogPath = perflog('www.sitepeed.io.chrome66.json');
   return parsePerflog(perflogPath, { includeTextFromResponseBody: true })
     .then(har => har.log)
     .tap(log =>
@@ -157,78 +157,78 @@ test("Includes response bodies", t => {
     );
 });
 
-test("Includes canceled response", t => {
-  const perflogPath = perflog("canceled-video.json");
+test('Includes canceled response', t => {
+  const perflogPath = perflog('canceled-video.json');
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => {
       const videoAsset = log.entries.find(
-        e => e.request.url === "https://www.w3schools.com/tags/movie.mp4"
+        e => e.request.url === 'https://www.w3schools.com/tags/movie.mp4'
       );
       t.is(videoAsset.timings.receive, 316.563);
       t.is(videoAsset.time, 343.33099999999996);
     });
 });
 
-test("Includes iframe request when frame is not attached", t => {
-  const perflogPath = perflog("iframe-not-attached.json");
+test('Includes iframe request when frame is not attached', t => {
+  const perflogPath = perflog('iframe-not-attached.json');
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => {
       const imageAsset = log.entries.filter(
-        e => e.request.url === "https://www.w3schools.com/html/img_girl.jpg"
+        e => e.request.url === 'https://www.w3schools.com/html/img_girl.jpg'
       );
       t.is(imageAsset.length, 1);
     });
 });
 
-test("Includes extra info in request", t => {
-  const perflogPath = perflog("www.calibreapp.com.signin.json");
+test('Includes extra info in request', t => {
+  const perflogPath = perflog('www.calibreapp.com.signin.json');
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => {
       const cssAsset = log.entries.find(e =>
         e.request.url.endsWith(
-          "sign_up_in-8b32538e54b23b40f8fd45c28abdcee2e2d023bd7e01ddf2033d5f781afae9dc.css"
+          'sign_up_in-8b32538e54b23b40f8fd45c28abdcee2e2d023bd7e01ddf2033d5f781afae9dc.css'
         )
       );
       t.is(cssAsset.request.headers.length, 15);
     });
 });
 
-test("Includes extra info in response", t => {
-  const perflogPath = perflog("www.calibreapp.com.signin.json");
+test('Includes extra info in response', t => {
+  const perflogPath = perflog('www.calibreapp.com.signin.json');
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => {
       const cssAsset = log.entries.find(e =>
         e.request.url.endsWith(
-          "sign_up_in-8b32538e54b23b40f8fd45c28abdcee2e2d023bd7e01ddf2033d5f781afae9dc.css"
+          'sign_up_in-8b32538e54b23b40f8fd45c28abdcee2e2d023bd7e01ddf2033d5f781afae9dc.css'
         )
       );
       t.is(cssAsset.response.headers.length, 14);
     });
 });
 
-test("Excludes request blocked cookies", t => {
-  const perflogPath = perflog("samesite-sandbox.glitch.me.json");
+test('Excludes request blocked cookies', t => {
+  const perflogPath = perflog('samesite-sandbox.glitch.me.json');
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => {
       const cookiesAsset = log.entries.find(e =>
-        e.request.url.endsWith("cookies.json")
+        e.request.url.endsWith('cookies.json')
       );
       t.is(cookiesAsset.request.cookies.length, 4);
     });
 });
 
-test("Excludes response blocked cookies", t => {
-  const perflogPath = perflog("response-blocked-cookies.json");
+test('Excludes response blocked cookies', t => {
+  const perflogPath = perflog('response-blocked-cookies.json');
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => {
       const request = log.entries.find(
-        e => e.request.url === "https://ow5u1.sse.codesandbox.io/"
+        e => e.request.url === 'https://ow5u1.sse.codesandbox.io/'
       );
       t.is(request.response.cookies.length, 1);
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,20 +1,20 @@
-import test from 'ava';
-import * as validator from 'har-validator';
-import * as Promise from 'bluebird';
-import * as fs from 'fs';
-import * as path from 'path';
-import parser from '../';
+import test from "ava";
+import * as validator from "har-validator";
+import * as Promise from "bluebird";
+import * as fs from "fs";
+import * as path from "path";
+import parser from "../";
 
 Promise.promisifyAll(fs);
 
-const PERFLOGSPATH = path.resolve(__dirname, 'perflogs');
+const PERFLOGSPATH = path.resolve(__dirname, "perflogs");
 
 /**
  * Validate that, for each tcp connection, the previous request is fully completed before then next starts.
  */
 function validateConnectionOverlap(t, entries) {
   const entriesByConnection = entries
-    .filter(entry => !['h2', 'spdy/3.1'].includes(entry.response.httpVersion))
+    .filter(entry => !["h2", "spdy/3.1"].includes(entry.response.httpVersion))
     .filter(entry => !(entry.cache || {}).beforeRequest)
     .reduce((entries, entry) => {
       const e = entries.get(entry.connection) || [];
@@ -45,7 +45,7 @@ function perflog(filename) {
 function perflogs() {
   return fs
     .readdirAsync(PERFLOGSPATH)
-    .filter(filename => path.extname(filename) === '.json');
+    .filter(filename => path.extname(filename) === ".json");
 }
 
 function parsePerflog(perflogPath, options) {
@@ -74,72 +74,72 @@ function testAllHARs(t, options) {
   });
 }
 
-test('Generates valid HARs', t => {
+test("Generates valid HARs", t => {
   return testAllHARs(t);
 });
 
-test('Generates valid HARs including cached entries', t => {
+test("Generates valid HARs including cached entries", t => {
   return testAllHARs(t, { includeResourcesFromDiskCache: true });
 });
 
-test('zdnet', t => {
-  const perflogPath = perflog('www.zdnet.com.json');
+test("zdnet", t => {
+  const perflogPath = perflog("www.zdnet.com.json");
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => t.is(log.pages.length, 1))
     .tap(log => t.is(log.entries.length, 343));
 });
 
-test('ryan', t => {
-  const perflogPath = perflog('ryan.json');
+test("ryan", t => {
+  const perflogPath = perflog("ryan.json");
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => t.is(log.pages.length, 1));
 });
 
-test('chrome66', t => {
-  const perflogPath = perflog('www.sitepeed.io.chrome66.json');
+test("chrome66", t => {
+  const perflogPath = perflog("www.sitepeed.io.chrome66.json");
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => t.is(log.entries.length, 9));
 });
 
-test('Parses IPv6 address', t => {
-  const perflogPath = perflog('www.google.ru.json');
+test("Parses IPv6 address", t => {
+  const perflogPath = perflog("www.google.ru.json");
   return parsePerflog(perflogPath).then(har =>
-    t.is(har.log.entries[0].serverIPAddress, '2a00:1450:400f:80a::2003')
+    t.is(har.log.entries[0].serverIPAddress, "2a00:1450:400f:80a::2003")
   );
 });
 
-test('navigatedWithinDocument', t => {
-  const perflogPath = perflog('navigatedWithinDocument.json');
+test("navigatedWithinDocument", t => {
+  const perflogPath = perflog("navigatedWithinDocument.json");
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => t.is(log.entries.length, 1));
 });
 
-test('Generates multiple pages', t => {
-  const perflogPath = perflog('www.wikipedia.org.json');
+test("Generates multiple pages", t => {
+  const perflogPath = perflog("www.wikipedia.org.json");
   return parsePerflog(perflogPath).tap(har => t.is(har.log.pages.length, 2));
 });
 
-test('Skips empty pages', t => {
-  const perflogPath = perflog('www.wikipedia.org-empty.json');
+test("Skips empty pages", t => {
+  const perflogPath = perflog("www.wikipedia.org-empty.json");
   return parsePerflog(perflogPath).tap(har => t.is(har.log.pages.length, 1));
 });
 
-test('Click on link in Chrome should create new page', t => {
-  const perflogPath = perflog('linkClickChrome.json');
+test("Click on link in Chrome should create new page", t => {
+  const perflogPath = perflog("linkClickChrome.json");
   return parsePerflog(perflogPath).tap(har => t.is(har.log.pages.length, 1));
 });
 
-test('Includes pushed assets', t => {
-  const perflogPath = perflog('akamai-h2push.json');
+test("Includes pushed assets", t => {
+  const perflogPath = perflog("akamai-h2push.json");
   return parsePerflog(perflogPath)
     .tap(har => t.is(har.log.pages.length, 1))
     .tap(har => {
       const images = har.log.entries.filter(e =>
-        e.request.url.startsWith('https://http2.akamai.com/demo/tile-')
+        e.request.url.startsWith("https://http2.akamai.com/demo/tile-")
       );
       t.is(images.length, 361); // 19*19 = 361 image tiles
 
@@ -148,8 +148,8 @@ test('Includes pushed assets', t => {
     });
 });
 
-test('Includes response bodies', t => {
-  const perflogPath = perflog('www.sitepeed.io.chrome66.json');
+test("Includes response bodies", t => {
+  const perflogPath = perflog("www.sitepeed.io.chrome66.json");
   return parsePerflog(perflogPath, { includeTextFromResponseBody: true })
     .then(har => har.log)
     .tap(log =>
@@ -157,78 +157,78 @@ test('Includes response bodies', t => {
     );
 });
 
-test('Includes canceled response', t => {
-  const perflogPath = perflog('canceled-video.json');
+test("Includes canceled response", t => {
+  const perflogPath = perflog("canceled-video.json");
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => {
       const videoAsset = log.entries.find(
-        e => e.request.url === 'https://www.w3schools.com/tags/movie.mp4'
+        e => e.request.url === "https://www.w3schools.com/tags/movie.mp4"
       );
       t.is(videoAsset.timings.receive, 316.563);
       t.is(videoAsset.time, 343.33099999999996);
     });
 });
 
-test('Includes iframe request when frame is not attached', t => {
-  const perflogPath = perflog('iframe-not-attached.json');
+test("Includes iframe request when frame is not attached", t => {
+  const perflogPath = perflog("iframe-not-attached.json");
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => {
       const imageAsset = log.entries.filter(
-        e => e.request.url === 'https://www.w3schools.com/html/img_girl.jpg'
+        e => e.request.url === "https://www.w3schools.com/html/img_girl.jpg"
       );
       t.is(imageAsset.length, 1);
     });
 });
 
-test('Includes extra info in request', t => {
-  const perflogPath = perflog('www.calibreapp.com.signin.json');
+test("Includes extra info in request", t => {
+  const perflogPath = perflog("www.calibreapp.com.signin.json");
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => {
       const cssAsset = log.entries.find(e =>
         e.request.url.endsWith(
-          'sign_up_in-8b32538e54b23b40f8fd45c28abdcee2e2d023bd7e01ddf2033d5f781afae9dc.css'
+          "sign_up_in-8b32538e54b23b40f8fd45c28abdcee2e2d023bd7e01ddf2033d5f781afae9dc.css"
         )
       );
       t.is(cssAsset.request.headers.length, 15);
     });
 });
 
-test('Includes extra info in response', t => {
-  const perflogPath = perflog('www.calibreapp.com.signin.json');
+test("Includes extra info in response", t => {
+  const perflogPath = perflog("www.calibreapp.com.signin.json");
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => {
       const cssAsset = log.entries.find(e =>
         e.request.url.endsWith(
-          'sign_up_in-8b32538e54b23b40f8fd45c28abdcee2e2d023bd7e01ddf2033d5f781afae9dc.css'
+          "sign_up_in-8b32538e54b23b40f8fd45c28abdcee2e2d023bd7e01ddf2033d5f781afae9dc.css"
         )
       );
       t.is(cssAsset.response.headers.length, 14);
     });
 });
 
-test('Excludes request blocked cookies', t => {
-  const perflogPath = perflog('samesite-sandbox.glitch.me.json');
+test("Excludes request blocked cookies", t => {
+  const perflogPath = perflog("samesite-sandbox.glitch.me.json");
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => {
       const cookiesAsset = log.entries.find(e =>
-        e.request.url.endsWith('cookies.json')
+        e.request.url.endsWith("cookies.json")
       );
       t.is(cookiesAsset.request.cookies.length, 4);
     });
 });
 
-test('Excludes response blocked cookies', t => {
-  const perflogPath = perflog('response-blocked-cookies.json');
+test("Excludes response blocked cookies", t => {
+  const perflogPath = perflog("response-blocked-cookies.json");
   return parsePerflog(perflogPath)
     .then(har => har.log)
     .tap(log => {
       const request = log.entries.find(
-        e => e.request.url === 'https://ow5u1.sse.codesandbox.io/'
+        e => e.request.url === "https://ow5u1.sse.codesandbox.io/"
       );
       t.is(request.response.cookies.length, 1);
     });


### PR DESCRIPTION
This PR fixes a bug where an error is thrown when the cookie object is missing from the blocked cookies array of a `Network.responseReceivedExtraInfo` event.

I missed this in my initial testing, but the `cookie` object is optional and might not be present, as per the [Network.responseReceivedExtraInfo  specification](https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-responseReceivedExtraInfo).

To fix this bug, this PR will check for the presence of the `cookie` object and if it exists use that, if not it will parse the `cookieLine` and use that. This PR also updates the test fixture to include a blocked cookie that is missing a `cookie` object.
