### PR TITLE
Pass encoding from response to entry

### DIFF
--- a/lib/entryFromResponse.js
+++ b/lib/entryFromResponse.js
@@ -81,7 +81,8 @@ module.exports = function(entry, response, page, options) {
     content: {
       mimeType: response.mimeType,
       size: 0,
-      text: text
+      text: text,
+      encoding: response.encoding
     },
     headersSize: -1,
     bodySize: -1,


### PR DESCRIPTION
Chromium seems to add an attribute `encoding: "base64"` to each `response.content` where `text` is a base64 encoded binary, to HAR files exported via DevTools UI.
This patch allows library users to set `encoding` themselves whenever needed.