### PR TITLE
Propagation of response.encoding

### DIFF
--- a/lib/entryFromResponse.js
+++ b/lib/entryFromResponse.js
@@ -81,7 +81,7 @@ module.exports = function(entry, response, page, options) {
     content: {
       encodig: response.encoding,
       mimeType: response.mimeType,
-      size: text!=null ?text.length:0,
+      size: text != null ? text.length : 0,
       text: text
     },
     headersSize: -1,

--- a/lib/entryFromResponse.js
+++ b/lib/entryFromResponse.js
@@ -79,8 +79,9 @@ module.exports = function(entry, response, page, options) {
     status: response.status,
     statusText: response.statusText,
     content: {
+      encodig: response.encoding,
       mimeType: response.mimeType,
-      size: 0,
+      size: text!=null ?text.length:0,
       text: text
     },
     headersSize: -1,


### PR DESCRIPTION
As per http://www.softwareishard.com/blog/har-12-spec/#content , there is "encoding" field in content. I need to be able to use it, because in my project I am base64 encoding certain reponses.