### PR TITLE
Do not add the extra parameters headers

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [16.x, 18.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/lib/entryFromResponse.js
+++ b/lib/entryFromResponse.js
@@ -34,14 +34,6 @@ module.exports = function(entry, response, page, options) {
   let headers = parseHeaders(responseHeaders);
 
   if (entry.extraResponseInfo) {
-    if (entry.extraResponseInfo.headers) {
-      headers = entry.extraResponseInfo.headers.concat(
-        headers.filter(
-          ({ name }) => !headers.find(header => header.name === name)
-        )
-      );
-    }
-
     if (entry.extraResponseInfo.blockedCookies) {
       cookies = cookies.filter(
         ({ name }) =>


### PR DESCRIPTION
Using the CDP Fetch API manipulating responses, the extra response info holds the old un-manipulated headers, so when copying the ones that do not exist, this breaks. 

Looking through some traces I couldn't see this change breaking anything (extra headers that is missed in the response). 