### PR TITLE
Support opt-in multi-page main-frame navigation HARs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+### Added
+* Add opt-in `allowMultiPage` support for main-frame scheduled/requested navigations so a second committed document request can create a new HAR page.
+
 ## 1.3.0 - 2026-05-06
 ### Added
 * Lift CDP `renderBlockingStatus` onto entries as `_renderBlocking` (Chrome 108+) so downstream HAR consumers (waterfall-tools'

--- a/README.md
+++ b/README.md
@@ -58,3 +58,13 @@ client.on('Network.requestIntercepted', async (params: any) => {
 
 const har = harFromMessages(harEvents, {includeTextFromResponseBody: true});
 ```
+
+## Multi-page Main Frame Navigations
+
+By default, main-document redirects and scripted navigations stay on one HAR page, preserving the historical behavior for one-measurement-per-page runs.
+
+Set `allowMultiPage` to `true` to create a new HAR page when Chrome reports a same-root-frame scheduled or requested navigation and the next committed document request starts:
+
+```javascript
+const har = harFromMessages(harEvents, {allowMultiPage: true});
+```

--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ const log = debug('chrome-har');
 
 const defaultOptions = {
   includeResourcesFromDiskCache: false,
-  includeTextFromResponseBody: false
+  includeTextFromResponseBody: false,
+  allowMultiPage: false
 };
 const isEmpty = o => !o;
 
@@ -69,7 +70,8 @@ export function harFromMessages(messages, options) {
   options = Object.assign({}, defaultOptions, options);
 
   const ignoredRequests = new Set(),
-    rootFrameMappings = new Map();
+    rootFrameMappings = new Map(),
+    pendingMainFrameNavigations = new Map();
 
   let pages = [],
     entries = [],
@@ -90,11 +92,27 @@ export function harFromMessages(messages, options) {
 
     switch (method) {
       case 'Page.frameStartedLoading':
+      case 'Page.frameScheduledNavigation':
       case 'Page.frameRequestedNavigation':
       case 'Page.navigatedWithinDocument': {
         {
           const frameId = params.frameId;
           const rootFrame = rootFrameMappings.get(frameId) || frameId;
+          const isMainFrame = rootFrame === frameId;
+          const isPendingNavigationEvent =
+            method === 'Page.frameScheduledNavigation' ||
+            method === 'Page.frameRequestedNavigation';
+          if (
+            options.allowMultiPage &&
+            isMainFrame &&
+            isPendingNavigationEvent &&
+            pages.some(page => page.__frameId === rootFrame)
+          ) {
+            pendingMainFrameNavigations.set(rootFrame, {
+              url: params.url || ''
+            });
+            continue;
+          }
           if (pages.some(page => page.__frameId === rootFrame)) {
             continue;
           }
@@ -178,7 +196,30 @@ export function harFromMessages(messages, options) {
             ignoredRequests.add(params.requestId);
             continue;
           }
-          const page = pages.at(-1);
+          const rootFrame =
+            rootFrameMappings.get(params.frameId) || params.frameId;
+          const isMainFrame = rootFrame === params.frameId;
+          let page = pages.at(-1);
+          if (
+            options.allowMultiPage &&
+            page &&
+            isMainFrame &&
+            params.type === 'Document' &&
+            pendingMainFrameNavigations.has(rootFrame)
+          ) {
+            const pendingNavigation =
+              pendingMainFrameNavigations.get(rootFrame);
+            currentPageId = randomUUID();
+            page = {
+              id: currentPageId,
+              startedDateTime: '',
+              title: pendingNavigation.url || request.url,
+              pageTimings: {},
+              __frameId: rootFrame
+            };
+            pages.push(page);
+            pendingMainFrameNavigations.delete(rootFrame);
+          }
           const cookieHeader = getHeaderValue(request.headers, 'Cookie');
 
           //Before we used to remove the hash framgment because of Chrome do that but:
@@ -427,10 +468,8 @@ export function harFromMessages(messages, options) {
             continue;
           }
 
-          const frameId =
-            rootFrameMappings.get(params.frameId) || params.frameId;
           const page =
-            pages.find(page => page.__frameId === frameId) || pages.at(-1);
+            pages.find(page => page.id === entry.pageref) || pages.at(-1);
           if (!page) {
             log(
               `Received network response for requestId ${params.requestId} that can't be mapped to any page.`
@@ -579,6 +618,15 @@ export function harFromMessages(messages, options) {
             rootFrameMappings.set(frameId, grandParentId);
             grandParentId = rootFrameMappings.get(grandParentId);
           }
+        }
+        break;
+      }
+
+      case 'Page.frameClearedScheduledNavigation': {
+        {
+          const frameId = params.frameId;
+          const rootFrame = rootFrameMappings.get(frameId) || frameId;
+          pendingMainFrameNavigations.delete(rootFrame);
         }
         break;
       }

--- a/test/tests.js
+++ b/test/tests.js
@@ -299,6 +299,111 @@ test('navigatedWithinDocument', t => {
     });
 });
 
+test('Main frame navigation can create a new page when enabled', t => {
+  const frameId = 'F1';
+  const request = (requestId, url, timestamp, type = 'Document') => [
+    {
+      method: 'Network.requestWillBeSent',
+      params: {
+        requestId,
+        frameId,
+        loaderId: `L${requestId}`,
+        documentURL: url,
+        request: {
+          url,
+          method: 'GET',
+          headers: {},
+          initialPriority: 'High'
+        },
+        timestamp,
+        wallTime: 1_700_000_000 + timestamp,
+        initiator: { type: 'other' },
+        type
+      }
+    },
+    {
+      method: 'Network.responseReceived',
+      params: {
+        requestId,
+        frameId,
+        loaderId: `L${requestId}`,
+        timestamp: timestamp + 0.01,
+        type,
+        response: {
+          url,
+          status: 200,
+          statusText: 'OK',
+          headers: { 'content-type': 'text/html' },
+          mimeType: 'text/html',
+          fromDiskCache: false,
+          fromServiceWorker: false,
+          encodedDataLength: 100,
+          protocol: 'http/1.1',
+          connectionId: Number(requestId),
+          remoteIPAddress: '127.0.0.1',
+          timing: {
+            requestTime: timestamp,
+            dnsStart: -1,
+            dnsEnd: -1,
+            connectStart: -1,
+            connectEnd: -1,
+            sslStart: -1,
+            sslEnd: -1,
+            sendStart: 0,
+            sendEnd: 1,
+            receiveHeadersEnd: 2
+          }
+        }
+      }
+    },
+    {
+      method: 'Network.loadingFinished',
+      params: {
+        requestId,
+        timestamp: timestamp + 0.05,
+        encodedDataLength: 100
+      }
+    }
+  ];
+
+  const messages = [
+    { method: 'Page.frameStartedLoading', params: { frameId } },
+    ...request('1', 'https://example.com/page1.html', 1),
+    ...request('2', 'https://example.com/page1.png', 1.5, 'Image'),
+    {
+      method: 'Page.frameScheduledNavigation',
+      params: {
+        delay: 0,
+        frameId,
+        reason: 'scriptInitiated',
+        url: 'https://example.com/page2.html'
+      }
+    },
+    { method: 'Page.frameStartedLoading', params: { frameId } },
+    ...request('3', 'https://example.com/page2.html', 3),
+    ...request('4', 'https://example.com/page2.png', 3.5, 'Image')
+  ];
+
+  const flatHar = harFromMessages(messages);
+  t.is(flatHar.log.pages.length, 1);
+  t.true(flatHar.log.entries.every(entry => entry.pageref === 'page_1'));
+
+  const multiPageHar = harFromMessages(messages, { allowMultiPage: true });
+  t.is(multiPageHar.log.pages.length, 2);
+  t.deepEqual(
+    multiPageHar.log.pages.map(page => page.title),
+    ['https://example.com/page1.html', 'https://example.com/page2.html']
+  );
+
+  const pageRefsByUrl = Object.fromEntries(
+    multiPageHar.log.entries.map(entry => [entry.request.url, entry.pageref])
+  );
+  t.is(pageRefsByUrl['https://example.com/page1.html'], 'page_1');
+  t.is(pageRefsByUrl['https://example.com/page1.png'], 'page_1');
+  t.is(pageRefsByUrl['https://example.com/page2.html'], 'page_2');
+  t.is(pageRefsByUrl['https://example.com/page2.png'], 'page_2');
+});
+
 test('Generates multiple pages', t => {
   const perflogPath = perflog('www.wikipedia.org.json');
   return parsePerflog(perflogPath).then(har => {


### PR DESCRIPTION
## Summary
- add an opt-in `allowMultiPage` option for same-root-frame scheduled/requested navigations
- create the new HAR page when the next main-frame document request commits, so page timing still comes from `Network.requestWillBeSent`
- route responses by `entry.pageref` before falling back to the latest page, which keeps timings correct when multiple HAR pages share one frame id
- document the option and add a regression for page1 -> page2 scripted navigation

Fixes #65
Gitpay task: https://gitpay.me/#/task/348

## Tests
- `npm test`
- `npm run lint`
- `git diff --check`